### PR TITLE
Serve web vitals module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import { GoogleLogger } from './google-logger';
 import { CoralogixLogger } from './coralogix-logger';
 import { CoralogixErrorLogger } from './coralogix-error-logger';
 import { respondRobots } from './robots.js';
+import { respondUnpkg } from './unpkg.js';
 
 function respondError(message, status, e, req) {
   const headers = new Headers();
@@ -47,6 +48,9 @@ async function main(req) {
   try {
     if (req.method === 'GET' && new URL(req.url).pathname.startsWith('/robots.txt')) {
       return respondRobots(req);
+    }
+    if (req.method === 'GET' && new URL(req.url).pathname.startsWith('/.rum/web-vitals')) {
+      return respondUnpkg(req);
     }
     const body = req.method === 'GET'
       ? JSON.parse(new URL(req.url).searchParams.get('data'))

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@
 import { GoogleLogger } from './google-logger';
 import { CoralogixLogger } from './coralogix-logger';
 import { CoralogixErrorLogger } from './coralogix-error-logger';
+import { respondRobots } from './robots.js';
 
 function respondError(message, status, e, req) {
   const headers = new Headers();
@@ -44,6 +45,9 @@ function hashCode(s) {
 
 async function main(req) {
   try {
+    if (req.method === 'GET' && req.url.startsWith('/robots.txt')) {
+      return respondRobots(req);
+    }
     const body = req.method === 'GET'
       ? JSON.parse(new URL(req.url).searchParams.get('data'))
       : await req.json();

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ function hashCode(s) {
 
 async function main(req) {
   try {
-    if (req.method === 'GET' && req.url.startsWith('/robots.txt')) {
+    if (req.method === 'GET' && new URL(req.url).pathname.startsWith('/robots.txt')) {
       return respondRobots(req);
     }
     const body = req.method === 'GET'

--- a/src/robots.js
+++ b/src/robots.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env serviceworker */
+export function respondRobots() {
+  return new Response(`
+User-agent: *
+Disallow: /`, {
+    headers: {
+      'content-type': 'text/plain',
+    },
+  });
+}

--- a/src/unpkg.js
+++ b/src/unpkg.js
@@ -20,9 +20,14 @@ export async function respondUnpkg(req) {
   });
   if (beresp.status === 302) {
     const bereq2 = new Request(new URL(beresp.headers.get('location'), 'https://unpkg.com'));
-    return fetch(bereq2, {
+    const beresp2 = await fetch(bereq2, {
       backend: 'unpkg.com',
     });
+
+    // override the cache control header
+    beresp2.headers.set('cache-control', beresp.headers.get('cache-control'));
+
+    return beresp2;
   }
   return beresp;
 }

--- a/src/unpkg.js
+++ b/src/unpkg.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env serviceworker */
+export async function respondUnpkg(req) {
+  const url = new URL(req.url);
+  const paths = url.pathname.split('/');
+  const beurl = new URL(paths.slice(2).join('/'), 'https://unpkg.com');
+  const bereq = new Request(beurl.href);
+  const beresp = await fetch(bereq, {
+    backend: 'unpkg.com',
+  });
+  if (beresp.status === 302) {
+    const bereq2 = new Request(new URL(beresp.headers.get('location'), 'https://unpkg.com'));
+    return fetch(bereq2, {
+      backend: 'unpkg.com',
+    });
+  }
+  return beresp;
+}

--- a/src/unpkg.js
+++ b/src/unpkg.js
@@ -10,6 +10,18 @@
  * governing permissions and limitations under the License.
  */
 /* eslint-env serviceworker */
+
+function cleanupHeaders(resp) {
+  ['access-control-allow-origin',
+    'cf-cache-status',
+    'cf-ray',
+    'expect-ct',
+    'fly-request-id',
+    'server',
+  ].forEach((headername) => resp.headers.delete(headername));
+  return resp;
+}
+
 export async function respondUnpkg(req) {
   const url = new URL(req.url);
   const paths = url.pathname.split('/');
@@ -27,7 +39,7 @@ export async function respondUnpkg(req) {
     // override the cache control header
     beresp2.headers.set('cache-control', beresp.headers.get('cache-control'));
 
-    return beresp2;
+    return cleanupHeaders(beresp2);
   }
-  return beresp;
+  return cleanupHeaders(beresp);
 }

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -55,6 +55,22 @@ describe('Helix RUM Collector Post-Deploy Tests', () => {
     expect(response).to.be.text;
   });
 
+  it('web vitals module is being served', async () => {
+    const response = await chai.request(`https://${domain}`)
+      .get('/.rum/web-vitals@2.1.3/dist/web-vitals.base.js');
+    expect(response).to.have.status(200);
+    // eslint-disable-next-line no-unused-expressions
+    expect(response).to.have.header('content-type', /^application\/javascript/);
+  });
+
+  it('web vitals module is being served without redirect', async () => {
+    const response = await chai.request(`https://${domain}`)
+      .get('/.rum/web-vitals/dist/web-vitals.base.js');
+    expect(response).to.have.status(200);
+    // eslint-disable-next-line no-unused-expressions
+    expect(response).to.have.header('content-type', /^application\/javascript/);
+  });
+
   it('Missing id returns 400', async () => {
     const response = await chai.request(`https://${domain}`)
       .post('/')

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -47,6 +47,14 @@ describe('Helix RUM Collector Post-Deploy Tests', () => {
     expect(response).to.have.status(201);
   });
 
+  it('robots.txt denies everything', async () => {
+    const response = await chai.request(`https://${domain}`)
+      .get('/robots.txt');
+    expect(response).to.have.status(200);
+    // eslint-disable-next-line no-unused-expressions
+    expect(response).to.be.text;
+  });
+
   it('Missing id returns 400', async () => {
     const response = await chai.request(`https://${domain}`)
       .post('/')


### PR DESCRIPTION
- feat: add robots.txt response
- fix(robots): use correct pathname for robots.txt
- feat(web-vitals): serve web-vitals module from rum collector
- fix(web-vitals): do not cache redirects forever
- feat(web-vitals): clean up response headers

The web vitals module is currently part of the helix boiler plate https://github.com/adobe/helix-project-boilerplate/tree/main/scripts and we would be better served by serving it directly from `/.rum/web-vitals...`

This PR adds the capability, with following features:

- https://helix-rum-collector-serve-through.hlx3.one/robots.txt discourages indexing of the domain
- https://helix-rum-collector-serve-through.hlx3.one/.rum/web-vitals@2.1.3/dist/web-vitals.base.js serves a specific version, with a "forever" cache setting (try 2.1.2, too)
- https://helix-rum-collector-serve-through.hlx3.one/.rum/web-vitals/dist/web-vitals.base.js serves the latest version, with a  shorter cache lifetime