### PR TITLE
feat(google): log to clustered table

### DIFF
--- a/src/google-logger.js
+++ b/src/google-logger.js
@@ -25,6 +25,7 @@ export class GoogleLogger {
     // eslint-disable-next-line: no-console
     // console.setEndpoint('Coralogix');
     this.logger = fastly.getLogger('BigQuery');
+    this.clusterlogger = fastly.getLogger('BigQuery-Clustered');
   }
 
   logRUM(json, id, weight, referer, generation, checkpoint, target, source) {
@@ -46,7 +47,7 @@ export class GoogleLogger {
       ...json,
     };
 
-    console.log(JSON.stringify(data));
     this.logger.log(JSON.stringify(data));
+    this.clusterlogger.log(JSON.stringify(data));
   }
 }

--- a/src/google-logger.js
+++ b/src/google-logger.js
@@ -47,7 +47,13 @@ export class GoogleLogger {
       ...json,
     };
 
+    const clusterdata = {
+      ...data,
+      time: now / 1000, // the cluster table uses TIMESTAMP for time, so that it can be partitioned
+      hostname: (new URL(data.url)).hostname, // the cluster table uses hostname for clustering
+    };
+
     this.logger.log(JSON.stringify(data));
-    this.clusterlogger.log(JSON.stringify(data));
+    this.clusterlogger.log(JSON.stringify(clusterdata));
   }
 }


### PR DESCRIPTION
This is a small change, with a larger potential payoff:

@davidnuescheler and I spoke about https://github.com/adobe/helix-run-query/pull/612 (ability to auto-coarsen the granularity for low-traffic pages) and the undesirable effect it has on query execution time and cost (the fewer data there is, the longer and costlier the query gets) and what we can do to mitigate that effect.

One idea was to create separate tables for each customer, then use the Google BigQuery streaming insert API directly to update these tables. This is not practical because Google charges for streaming inserts in increments of 1 KB, so our tiny RUM update would be very costly.

Fortunately, Google BigQuery offers two features that help with our use case.

1. by partitioning data based on `time`(stamp), a separate data file will be created for every day that sees data inserts. When querying and using `WHERE time`-conditions, these files will be opened selectively, greatly reducing the amount of data read (and billed)
2. by clustering based on `hostname`, a separate data file will be created for every unique hostname. Again, when querying with `WHERE hostname`-conditions, only files with a matching `hostname` will be processed, bringing cost further down.

As the relevant queries for RUM data are always time-based and overwhelmingly hostname-filtered, using this feature can be very beneficial. For testing, I've created a sample `cluster` table using:

```sql
CREATE OR REPLACE TABLE `helix-225321.helix_rum.cluster`
PARTITION BY DATE(time)
CLUSTER BY hostname
AS
SELECT REGEXP_EXTRACT(url, "https://([^/]+)/", 1) AS hostname, host, user_agent, TIMESTAMP_MILLIS(CAST(time AS INT64)) AS time, url, LCP, FID, CLS, referer, id, weight, generation FROM `helix-225321.helix_rum.rum2*`
```

so that the unclustered query
```sql
SELECT * FROM `helix_rum.rum2022*` WHERE _TABLE_SUFFIX > "02"
AND url LIKE "https://www.adobe.com/%"
AND TIMESTAMP_MILLIS(CAST(time AS INT64)) > "2022-03-12"
```

and the clustered query
```sql
SELECT * FROM `helix-225321.helix_rum.cluster` 
WHERE DATE(time) > "2022-03-12" 
AND hostname = "www.adobe.com"
```

are equivalent.

Where the unclustered query processed 1250 MB, the clustered query processed only 735 MB. Moving the date condition to `2022-03-01` changes the data amount processed by the clustered query to 971 MB (the unclustered stays the same).

As the number of hostnames grows, this effect will become more pronounced.

With this PR, we will log into both the clustered and the unclustered table, so that the queries in `helix-run-query` can be adjusted to take advantage of the optimized data storage. Note that the `CREATE OR REPLACE TABLE` DML statement above will have to be run again to ensure there is no gap in data between the two formats.