### PR TITLE
feat(coralogix): raise the severity of `checkpoint: error` to `error`

### DIFF
--- a/src/coralogix-logger.js
+++ b/src/coralogix-logger.js
@@ -36,7 +36,7 @@ export class CoralogixLogger {
       timestamp: now,
       applicationName: 'helix-rum-collector',
       subsystemName: this.subsystemName,
-      severity: 3,
+      severity: checkpoint === 'error' ? 5 : 3,
       json: {
         edgecompute: {
           url: this.req.url,


### PR DESCRIPTION
This will allow better alerts in Coralogix for client-side errors seen by RUM
