### PR TITLE
WIP: Support Adobe Experience Edge as a log target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
               echo New Service $ID;
               fastly domain  add          -t $HLX_FASTLY_AUTH -s $ID --version=1 --name=${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BRANCH}.hlx3.one
               fastly backend add          -t $HLX_FASTLY_AUTH -s $ID --version=1 --name=unpkg.com --address=unpkg.com --use-ssl --override-host=unpkg.com --port=443
+              fastly backend add          -t $HLX_FASTLY_AUTH -s $ID --version=1 --name=experience-edge --address=edge.adobedc.net --use-ssl --override-host=edge.adobedc.net --port=443
               fastly logging https create -t $HLX_FASTLY_AUTH -s $ID --version=1 --name=Coralogix --content-type=application/json --header-name=private_key --header-value=$CORALOGIX_KEY --url=https://api.coralogix.com/logs/rest/singles --json-format=1 --message-type=blank --placement=none
             else
               echo "ID is set to '$ID'";

--- a/src/experience-edge-logger.js
+++ b/src/experience-edge-logger.js
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* global fetch */
+
+export class ExperienceEdgeLogger {
+  constructor(req) {
+    this.req = req;
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  async logRUM(json, id, weight, referer, generation, checkpoint, target, source) {
+    console.log('logging to experience edge');
+
+    // most of this is copied from the example, but it's a start
+    const data = {
+      events: [
+        {
+          xdm: {
+            eventType: 'web.webpagedetails.pageViews',
+            web: {
+              webPageDetails: {
+                URL: referer || (this.req.headers.has('referer') ? this.req.headers.get('referer') : this.req.url),
+              },
+              webReferrer: {
+                URL: '',
+              },
+            },
+            device: {
+              screenHeight: 2160,
+              screenWidth: 3840,
+              screenOrientation: 'landscape',
+            },
+            environment: {
+              type: 'browser',
+              browserDetails: {
+                viewportWidth: 1578,
+                viewportHeight: 226,
+              },
+            },
+            placeContext: {
+              localTime: '2021-12-08T14:11:55.763-07:00',
+              localTimezoneOffset: 420,
+            },
+            timestamp: new Date().toISOString(),
+            implementationDetails: {
+              name: 'https://ns.adobe.com/experience/alloy/reactor',
+              version: generation,
+              environment: 'browser',
+            },
+          },
+          query: {
+            personalization: {
+              schemas: [
+                'https://ns.adobe.com/personalization/html-content-item',
+                'https://ns.adobe.com/personalization/json-content-item',
+                'https://ns.adobe.com/personalization/redirect-item',
+                'https://ns.adobe.com/personalization/dom-action',
+              ],
+              decisionScopes: [
+                '__view__',
+              ],
+            },
+          },
+          data: {
+            test: 'pass',
+          },
+        },
+      ],
+      query: {
+        identity: {
+          fetch: [
+            'ECID',
+          ],
+        },
+      },
+      meta: {
+        state: {
+          domain: 'example.com',
+          cookiesEnabled: true,
+          entries: [
+            {
+              key: 'kndctr_97D1F3F459CE0AD80A495CBE_AdobeOrg_identity',
+              value: 'CiY4MzQxODI0Nzg4NTE1NzE3MDcwMTI4MzMwNTc3NjEyNjg3Mjk2OFIOCPORubbZLxgBKgNPUjLwAfORubbZLw==',
+            },
+            {
+              key: 'kndctr_97D1F3F459CE0AD80A495CBE_AdobeOrg_consent',
+              value: 'general=in',
+            },
+          ],
+        },
+      },
+    };
+
+    const endpoint = new URL('https://edge.adobedc.net/ee/v1/collect?configId=7cca5ac0-0a9e-4caa-98f8-e0cae555b171:prod');
+    endpoint.searchParams.append('requestId', id);
+    // headers from curl:
+    // -H 'Connection: keep-alive'
+    // -H 'Pragma: no-cache'
+    // -H 'Cache-Control: no-cache'
+    // -H 'Sec-Fetch-Dest: empty'
+    // -H 'Content-Type: text/plain; charset=UTF-8'
+    // -H 'Accept: */*'
+    // -H 'Origin: http://localhost:8080'
+    // -H 'Sec-Fetch-Site: cross-site'
+    // -H 'Sec-Fetch-Mode: cors'
+    // -H 'Referer: http://localhost:8080/client'
+    // -H 'Accept-Language: en,ro;q=0.9'
+    const options = {
+      backend: 'experience-edge',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/plain; charset=UTF-8',
+        Accept: '*/*',
+        Origin: 'http://localhost:8080',
+        'Sec-Fetch-Site': 'cross-site',
+        'Sec-Fetch-Mode': 'cors',
+        'Sec-Fetch-Dest': 'empty',
+        Referer: referer || (this.req.headers.has('referer') ? this.req.headers.get('referer') : this.req.url),
+        'Accept-Language': 'en,ro;q=0.9',
+        'User-Agent': this.req.headers.get('User-Agent'),
+      },
+      body: JSON.stringify(data),
+    };
+    // make a fetch request to the experience edge using the data above
+
+    const response = await fetch(endpoint, options);
+    console.log('response from experience edge', response.status, response.statusText);
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import { CoralogixLogger } from './coralogix-logger';
 import { CoralogixErrorLogger } from './coralogix-error-logger';
 import { respondRobots } from './robots.js';
 import { respondUnpkg } from './unpkg.js';
+import { ExperienceEdgeLogger } from './experience-edge-logger.js';
 
 function respondError(message, status, e, req) {
   const headers = new Headers();
@@ -88,6 +89,9 @@ async function main(req) {
 
       const g = new GoogleLogger(req);
       g.logRUM(cwv, id, weight, referer || referrer, generation, checkpoint, target, source);
+
+      const e = new ExperienceEdgeLogger(req);
+      e.logRUM(cwv, id, weight, referer || referrer, generation, checkpoint, target, source);
     } catch (err) {
       return respondError(`Could not collect RUM: ${err.message}`, 500, err, req);
     }


### PR DESCRIPTION
- feat(aep): add experience edge logger this logger uses the `fetch` API over the regular log streaming API as experience edge is not yet prepared to take logs straight from Fastly
- deploy(fastly): add backend for experience edge
- feat(index): add experience edge logger to baseline

Still very much work in progress, let's see where it leads
