### PR TITLE
feat(index): enable reporting CSPs as RUM events

### DIFF
--- a/src/google-logger.js
+++ b/src/google-logger.js
@@ -29,7 +29,7 @@ export class GoogleLogger {
   }
 
   logRUM(json, id, weight, referer, generation, checkpoint, target, source) {
-    console.log('logging to Google');
+    console.log('logging to Google, checkpoint: ', checkpoint);
     const now = Math.floor(Date.now());
 
     const data = {

--- a/src/google-logger.js
+++ b/src/google-logger.js
@@ -53,7 +53,9 @@ export class GoogleLogger {
       hostname: (new URL(data.url)).hostname, // the cluster table uses hostname for clustering
     };
 
+    console.log('ready to log (Google)');
     this.logger.log(JSON.stringify(data));
     this.clusterlogger.log(JSON.stringify(clusterdata));
+    console.log('logged (Google)');
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ async function main(req) {
       ? JSON.parse(new URL(req.url).searchParams.get('data'))
       : await req.json();
     if (req.method === 'POST' && req.headers.get('content-type') === 'application/csp-report') {
+      const report = body['csp-report'];
       // we need to re-jiggle the body a bit to make the CSP report look like a RUM report
       body.weight = 0; // CSP reports have no weight
       // const example = {
@@ -72,11 +73,11 @@ async function main(req) {
       //   'status-code': 200,
       //   'script-sample': '',
       // };
-      body.id = `${hashCode(body['document-uri'] || req.url)}-${new Date().getTime()}-${Math.random().toString(16).substr(2, 14)}`;
+      body.id = `${hashCode(report['document-uri'] || req.url)}-${new Date().getTime()}-${Math.random().toString(16).substr(2, 14)}`;
       body.checkpoint = 'csp';
-      body.target = body['blocked-uri'];
-      body.source = body['violated-directive'];
-      body.referer = body.referrer;
+      body.target = report['blocked-uri'];
+      body.source = report['violated-directive'];
+      body.referer = report.referrer;
     }
 
     const headers = new Headers();

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ async function main(req) {
     if (!id) {
       return respondError('id field is required', 400, undefined, req);
     }
-    if (!weight || typeof weight !== 'number') {
+    if (typeof weight !== 'number') {
       return respondError('weight must be a number', 400, undefined, req);
     }
     if (typeof cwv !== 'object') {

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ async function main(req) {
       body.checkpoint = 'csp';
       body.target = report['blocked-uri'];
       body.source = report['violated-directive'];
-      body.referer = report.referrer;
+      body.referer = report['document-uri'];
     }
 
     const headers = new Headers();


### PR DESCRIPTION
Content Security Policy violations will be reported as RUM events with a weight of 0, so that they don't inflate the page view count
