### PR TITLE
fix(logger): move triple slash reference types to correct source file

### DIFF
--- a/src/coralogix-error-logger.mjs
+++ b/src/coralogix-error-logger.mjs
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/// <reference types="@fastly/js-compute" />
 import { Logger } from './logger.mjs';
 
 export class CoralogixErrorLogger {

--- a/src/coralogix-logger.mjs
+++ b/src/coralogix-logger.mjs
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/// <reference types="@fastly/js-compute" />
 import { Logger } from './logger.mjs';
 import { cleanurl } from './utils.mjs';
 

--- a/src/google-logger.mjs
+++ b/src/google-logger.mjs
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/// <reference types="@fastly/js-compute" />
 import { Logger } from './logger.mjs';
 import { cleanurl } from './utils.mjs';
 

--- a/src/logger.mjs
+++ b/src/logger.mjs
@@ -11,6 +11,7 @@
  */
 // this thing is only for testing, so we ignore it in code coverage
 /* c8 ignore start */
+/// <reference types="@fastly/js-compute" />
 export let lastLogMessage = [];
 
 export class Logger {


### PR DESCRIPTION
It was left over in the specific logger impl files from before when the fastly:logger access was moved to logger.mjs