### PR TITLE
fix(logger): spread the timestamps a little when time padding is missing

### DIFF
--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -16,10 +16,23 @@ export function maskTime(time, timePadding) {
   if (timePadding) {
     return nearestHour + timePadding;
   } else {
-    return nearestHour;
+    // If the padding is missing we use the current second to spread
+    // the result a little bit. We drop the current minute and the
+    // current milliseconds
+    const numSeconds = Math.floor((time - nearestHour) / 1000);
+    const currentSecondAsMS = (numSeconds % 60) * 1000;
+
+    return nearestHour + currentSecondAsMS;
   }
 }
 
+/**
+ * Mask the current time by truncating it to the current hour and
+ * adding the padding provided.
+ *
+ * @param {number} timePadding the padding to be added.
+ * @returns the masked time.
+ */
 export function getMaskedTime(timePadding) {
   return maskTime(Date.now(), timePadding);
 }

--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -20,6 +20,13 @@ describe('Test Utils', () => {
     const timePadding = 12345;
 
     assert.equal(nearestHour + timePadding, maskTime(now, timePadding));
-    assert.equal(nearestHour, maskTime(now));
+  });
+
+  it('Use current second if padding is missing', () => {
+    const sometime = new Date(2023, 8, 6, 15, 45, 27, 999);
+
+    const expectedTime = new Date(2023, 8, 6, 15, 0, 27).getTime();
+    const masked = maskTime(sometime);
+    assert.equal(expectedTime, masked);
   });
 });


### PR DESCRIPTION
By using the current second atop the current hour (dropping minutes and milliseconds) - only when the time padding is not set.

## Related Issues

#192 