### PR TITLE
Detect mobile and desktop operating system from user agent string

### DIFF
--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -51,6 +51,35 @@ export function getMaskedTime(timePadding) {
   return maskTime(Date.now(), timePadding);
 }
 
+/**
+ * Extract the OS from the user agent string
+ * @returns {Enumerator(':android', ':ios', ':ipados', '')} the OS
+ */
+function getMobileOS(userAgent) {
+  if (userAgent.includes('android')) {
+    return ':android';
+  } else if (userAgent.includes('ipad')) {
+    return ':ipados';
+  } else if (userAgent.includes('like mac os')) {
+    return ':ios';
+  }
+  return '';
+}
+/**
+ * Extract the OS from the user agent string
+ * @returns {Enumerator(':windows', ':mac', ':linux', '')} the OS
+ */
+function getDesktopOS(userAgent) {
+  if (userAgent.includes('windows')) {
+    return ':windows';
+  } else if (userAgent.includes('mac os')) {
+    return ':mac';
+  } else if (userAgent.includes('linux')) {
+    return ':linux';
+  }
+  return '';
+}
+
 export function getMaskedUserAgent(headers) {
   if (!headers) {
     return 'undefined';
@@ -75,7 +104,7 @@ export function getMaskedUserAgent(headers) {
 
   if (lcUA.includes('mobile')
     || lcUA.includes('opera mini')) {
-    return 'mobile';
+    return `mobile${getMobileOS(lcUA)}`;
   }
   if (lcUA.includes('bot')
     || lcUA.includes('spider')

--- a/test/google-logger.test.mjs
+++ b/test/google-logger.test.mjs
@@ -42,7 +42,7 @@ describe('Test Google Logger', () => {
     assert(logged.time.toString().endsWith('00.011'), logged.time.toString());
     assert.equal('www.foo.com', logged.host);
     assert.equal('http://www.foo.com/referer', logged.url);
-    assert.equal('mobile', logged.user_agent);
+    assert.equal('mobile:android', logged.user_agent);
     assert.equal(5, logged.weight);
     assert.equal(67, logged.generation);
     assert.equal(9999999999999, logged.checkpoint);

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -127,7 +127,7 @@ describe('Test index', () => {
   it('error handling', async () => {
     const headers = new Map();
     headers.set('host', 'some.host');
-    headers.set('user-agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/117.0');
+    headers.set('user-agent', 'Mozilla/5.0 (X11; Linux i686; rv:10.0) Gecko/20100101 Firefox/10.0');
 
     const json = () => JSON.parse('{"malformed"}');
 
@@ -150,7 +150,7 @@ describe('Test index', () => {
     assert.equal('http://foo.bar.org', loggedJSON.edgecompute.url);
     assert.equal('http://foo.bar.org', loggedJSON.cdn.url);
     assert.equal('POST', loggedJSON.request.method);
-    assert.equal('desktop', loggedJSON.request.user_agent);
+    assert.equal('desktop:linux', loggedJSON.request.user_agent);
     assert(logged.timestamp.toString().endsWith('000'));
     assert.equal(logged.timestamp, loggedJSON.time.start_msec);
     assert(loggedJSON.message.startsWith('RUM Collector expects'));

--- a/test/s3-logger.test.mjs
+++ b/test/s3-logger.test.mjs
@@ -50,7 +50,7 @@ describe('Test S3 Logger', () => {
     assert.equal(logged.target.toString(), 'http://www.foo.com/target');
     assert.equal(logged.source.toString(), 'http://www.foo.com/source');
     assert.equal(logged.id, 'someid');
-    assert.equal(logged.user_agent, 'desktop');
+    assert.equal(logged.user_agent, 'desktop:windows');
     assert.deepEqual(logged.foo, ['b', 'ar']);
   });
 });

--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -63,8 +63,8 @@ describe('Test Utils', () => {
   }
 
   it('Mask user agent', () => {
-    assert.equal('mobile', getMaskedUserAgent(getUserAgentHeaders('Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Mobile/15E148 Safari/604.1')));
-    assert.equal('mobile', getMaskedUserAgent(getUserAgentHeaders('Mozilla/5.0 (iPad; CPU OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/20G75 [FBAN/FBIOS;FBDV/iPad11,3;FBMD/iPad;FBSN/iPadOS;FBSV/16.6;FBSS/2;FBID/tablet;FBLC/en_US;FBOP/5];FBNV/1')));
+    assert.equal('mobile:ios', getMaskedUserAgent(getUserAgentHeaders('Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Mobile/15E148 Safari/604.1')));
+    assert.equal('mobile:ipados', getMaskedUserAgent(getUserAgentHeaders('Mozilla/5.0 (iPad; CPU OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/20G75 [FBAN/FBIOS;FBDV/iPad11,3;FBMD/iPad;FBSN/iPadOS;FBSV/16.6;FBSS/2;FBID/tablet;FBLC/en_US;FBOP/5];FBNV/1')));
     assert.equal('mobile', getMaskedUserAgent(getUserAgentHeaders('Opera/9.80 (SpreadTrum; Opera Mini/4.4.33961/191.315; U; fr) Presto/2.12.423 Version/12.16')));
 
     assert.equal('bot', getMaskedUserAgent(getUserAgentHeaders('Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)')));
@@ -72,9 +72,9 @@ describe('Test Utils', () => {
     assert.equal('bot', getMaskedUserAgent(getUserAgentHeaders('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36 PingdomPageSpeed/1.0 (pingbot/2.0; +http://www.pingdom.com/)')));
     assert.equal('bot', getMaskedUserAgent(getUserAgentHeaders('AHC/2.1')));
 
-    assert.equal('desktop', getMaskedUserAgent(getUserAgentHeaders('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.5563.64 Safari/537.36')));
-    assert.equal('desktop', getMaskedUserAgent(getUserAgentHeaders('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Sidekick/6.30.0')));
-    assert.equal('desktop', getMaskedUserAgent(getUserAgentHeaders('Opera/12.0(Windows NT 5.2;U;en)Presto/22.9.168 Version/12.00')));
+    assert.equal('desktop:windows', getMaskedUserAgent(getUserAgentHeaders('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.5563.64 Safari/537.36')));
+    assert.equal('desktop:mac', getMaskedUserAgent(getUserAgentHeaders('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Sidekick/6.30.0')));
+    assert.equal('desktop:windows', getMaskedUserAgent(getUserAgentHeaders('Opera/12.0(Windows NT 5.2;U;en)Presto/22.9.168 Version/12.00')));
     assert.equal('desktop', getMaskedUserAgent(getUserAgentHeaders('foobar')));
 
     assert.equal('undefined', getMaskedUserAgent(new Map()));


### PR DESCRIPTION
This changes the `user_agent` value reported from `mobile` or `desktop` to `mobile:ios`, `mobile:android`, `mobile:ipados`, `desktop:windows`, `desktop:mac`, `desktop:linux` if the operating system can be determined. It will stay `mobile` or `desktop` for unknow operating systems
