### PR TITLE
Classify Consent Clicks under `consent` checkpoint

### DIFF
--- a/src/consent.mjs
+++ b/src/consent.mjs
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const vendors = {
+  onetrust: {
+    match: /#(onetrust|ot)-/,
+    accept: /accept/,
+    reject: /reject/,
+    dismiss: /close-pc-btn-handler/,
+  },
+  usercentrics: {
+    match: /#usercentrics-root/,
+    // we don't have nicely id'd buttons here
+  },
+  truste: {
+    match: /#truste/,
+    accept: /consent-button/,
+    dismiss: /close/,
+  },
+  cybot: {
+    match: /#CybotCookiebot/,
+    accept: /AllowAll/,
+    reject: /Decline/,
+  },
+};
+
+export function classifyConsent(cssSelector) {
+  return cssSelector
+    && (Object.entries(vendors)
+      .filter(([_, { match }]) => match.test(cssSelector))
+      .map(([vendor, spec]) => ({
+        checkpoint: 'consent',
+        source: vendor,
+        target: Object.entries(spec)
+          .filter(([key]) => key !== 'match')
+          .filter(([_, pattern]) => pattern.test(cssSelector))
+          .map(([key]) => key)
+          .pop(),
+      }))).pop();
+}

--- a/src/google-logger.mjs
+++ b/src/google-logger.mjs
@@ -14,6 +14,7 @@ import {
   cleanurl, getMaskedTime, getMaskedUserAgent, getSubsystem, isReasonableWeight, isValidCheckpoint,
 } from './utils.mjs';
 import { classifyAcquisition } from './acquisition.mjs';
+import { classifyConsent } from './consent.mjs';
 
 export class GoogleLogger {
   constructor(req) {
@@ -39,6 +40,12 @@ export class GoogleLogger {
     if (checkpoint === 'paid' || checkpoint === 'email') {
       checkpoint = 'acquisition';
       source = classifyAcquisition(source, true);
+    }
+    const consent = checkpoint === 'click' && classifyConsent(source);
+    if (consent) {
+      checkpoint = consent.checkpoint;
+      source = consent.source;
+      target = consent.target;
     }
 
     const data = {

--- a/src/s3-logger.mjs
+++ b/src/s3-logger.mjs
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { classifyAcquisition } from './acquisition.mjs';
+import { classifyConsent } from './consent.mjs';
 import { Logger } from './logger.mjs';
 import {
   cleanurl, getMaskedTime, getMaskedUserAgent, getSubsystem, isReasonableWeight, isValidCheckpoint,
@@ -39,6 +40,12 @@ export class S3Logger {
     if (checkpoint === 'paid' || checkpoint === 'email') {
       checkpoint = 'acquisition';
       source = classifyAcquisition(source, true);
+    }
+    const consent = checkpoint === 'click' && classifyConsent(source);
+    if (consent) {
+      checkpoint = consent.checkpoint;
+      source = consent.source;
+      target = consent.target;
     }
 
     const data = {

--- a/test/consent.test.mjs
+++ b/test/consent.test.mjs
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import assert from 'assert';
+import { describe, it } from 'node:test';
+import { classifyConsent } from '../src/consent.mjs';
+
+describe('classifyConsent', () => {
+  const testCases = [
+    { selector: '#onetrust-accept-btn-handler', source: 'onetrust', target: 'accept' },
+    { selector: '#onetrust-reject-all-handler', source: 'onetrust', target: 'reject' },
+    { selector: '#onetrust-close-pc-btn-handler', source: 'onetrust', target: 'dismiss' },
+    { selector: '#usercentrics-root', source: 'usercentrics', target: undefined },
+    { selector: '#truste-consent-button', source: 'truste', target: 'accept' },
+    { selector: '#CybotCookiebotDialogBodyButtonDecline', source: 'cybot', target: 'reject' },
+    { selector: '#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll', source: 'cybot', target: 'accept' },
+    // Negative test cases
+    { selector: '#unknown-selector', source: undefined, target: undefined },
+    { selector: '.button', source: undefined, target: undefined },
+    { selector: '.hero', source: undefined, target: undefined },
+    { selector: '.columns', source: undefined, target: undefined },
+    { selector: 'form button', source: undefined, target: undefined },
+    { selector: 'form input[type="text"]', source: undefined, target: undefined },
+    { selector: '#main-content', source: undefined, target: undefined },
+    { selector: '.cards', source: undefined, target: undefined },
+    { selector: '.carousel', source: undefined, target: undefined },
+    { selector: '#header', source: undefined, target: undefined },
+    { selector: '.footer', source: undefined, target: undefined },
+    { selector: '#search', source: undefined, target: undefined },
+    { selector: '#map', source: undefined, target: undefined },
+    { selector: '#spa-root', source: undefined, target: undefined },
+    { selector: '#app', source: undefined, target: undefined },
+    { selector: '#stage', source: undefined, target: undefined },
+    { selector: '#root', source: undefined, target: undefined },
+    { selector: '#navigation', source: undefined, target: undefined },
+  ];
+
+  testCases.forEach(({ selector, source, target }) => {
+    it(`should find ${source} (${target}) in ${selector}`, () => {
+      const result = classifyConsent(selector);
+
+      if (source || target) {
+        assert.equal(result.checkpoint, 'consent');
+        assert.equal(result.source, source);
+        assert.equal(result.target, target);
+      } else {
+        assert.ok(result === undefined, 'result should be undefined');
+      }
+    });
+  });
+});


### PR DESCRIPTION
- **feat(consent): new classifier for consent clicks**
- **feat(google): log reclassified consent to google**
- **feat(s3): log reclassified consent to s3**

Clicks on consent dialogs are an important interaction to understand (especially in
the light of low rates of opt-in), so we track them under the `consent` checkpoint
if possible. This means the signal ratio for the `click` checkpoint will be higher
as only clicks on the actual page will be considered
