### PR TITLE
fix(utils): strip away JWT tokens in paths

### DIFF
--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -205,6 +205,14 @@ export function getMaskedUserAgent(headers) {
   return `desktop${getDesktopOS(lcUA)}`;
 }
 
+function cleanJWT(str) {
+  // sometimes we see JWTs in URLs or source or target values. These
+  // are always two segments of base64-encoded JSON and a signature,
+  // separated by three dots. When we find this, we replace the string
+  // with a generic placeholder.
+  return str && str.replace(/eyJ[a-zA-Z0-9]+\.eyJ[a-zA-Z0-9]+\.[a-zA-Z0-9]+/g, '<jwt>');
+}
+
 export function cleanurl(url) {
   // if URL does not parse, return it as is
   try {
@@ -214,9 +222,10 @@ export function cleanurl(url) {
     u.username = '';
     u.password = '';
     u.hash = '';
+    u.pathname = cleanJWT(u.pathname);
     return u.toString();
   } catch (e) {
-    return url;
+    return cleanJWT(url);
   }
 }
 

--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -110,6 +110,8 @@ describe('Test Utils', () => {
     assert.equal('http://foo.bar.com/test', cleanurl('http://foo.bar.com/test?foo=bar'));
     assert.equal('http://foo.bar.com/test', cleanurl('http://foo.bar.com/test?foo=bar#with-fragment'));
     assert.equal('http://foo.bar.com:9091/test', cleanurl('http://someone:something@foo.bar.com:9091/test'));
+    // jwt tokens in URLs are discarded
+    assert.equal(cleanurl('https://www.example.com/eyJmYWtlIjogdHJ1ZX0.eyJmYWtlIjogdHJ1ZX0.c3VwZXJmYWtl/auth'), 'https://www.example.com/%3Cjwt%3E/auth');
   });
 
   it('Get Forwarded Host', () => {


### PR DESCRIPTION
These should not make it into regular URLs, but better get rid of them proactively
