### PR TITLE
fix(cloudflare): clean up urls for real

### DIFF
--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -231,9 +231,9 @@ export function cleanurl(url) {
     u.password = '';
     u.hash = '';
     u.pathname = cleanJWT(u.pathname);
-    return u.toString();
+    return u.toString().replace(/@/g, '');
   } catch (e) {
-    return cleanJWT(url);
+    return cleanJWT(url).replace(/@/g, '');
   }
 }
 

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -233,7 +233,7 @@ export function cleanurl(url) {
     u.pathname = cleanJWT(u.pathname);
     return u.toString().replace(/@/g, '');
   } catch (e) {
-    return cleanJWT(url).replace(/@/g, '');
+    return cleanJWT(url);
   }
 }
 


### PR DESCRIPTION
the URL implementation in cloudflare keeps an `@` for the username, even
if username and password have been emptied. This normalizes the behavior
