### PR TITLE
Bloat Control

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "fastly-build": "hedy --build --verbose",
     "deploy": "hedy --build --verbose --deploy --fastly-auth $HLX_FASTLY_AUTH --compute-service-id ${HLX_FASTLY_SVC:-5Qir8H8bLeaRuldIp9TWq4} --cloudflare-email $HLX_CLOUDFLARE_EMAIL --cloudflare-account-id $HLX_CLOUDFLARE_ACCOUNT --cloudflare-auth $HLX_CLOUDFLARE_AUTH --name ${HLX_CLOUDFLARE_NAME:-helix-rum-collector-prod}",
     "predeploy": "node tools/spider-list.js",
-    "test": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=junit.xml",
+    "test": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=junit.xml --test-skip-pattern=Post-Deploy",
     "pretest": "node tools/spider-list.js",
     "test-postdeploy": "TEST_INTEGRATION=true node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=junit.xml --test-name-pattern=Post-Deploy",
     "prelint": "node tools/spider-list.js",

--- a/src/coralogix-logger.mjs
+++ b/src/coralogix-logger.mjs
@@ -11,6 +11,7 @@
  */
 import { Logger } from './logger.mjs';
 import {
+  bloatControl,
   cleanurl, getMaskedTime, getMaskedUserAgent, getSubsystem,
   isReasonableWeight,
   isValidCheckpoint,
@@ -89,7 +90,7 @@ export class CoralogixLogger {
     };
     console.log('ready to log (coralogix)');
     // console.log(JSON.stringify(data));
-    this.logger.log(JSON.stringify(data));
+    this.logger.log(bloatControl(data));
     console.log('done');
   }
 }

--- a/src/google-logger.mjs
+++ b/src/google-logger.mjs
@@ -11,6 +11,7 @@
  */
 import { Logger } from './logger.mjs';
 import {
+  bloatControl,
   cleanurl,
   getMaskedTime,
   getMaskedUserAgent,
@@ -69,6 +70,6 @@ export class GoogleLogger {
       url: cleanurl(data.url),
     };
 
-    this.clusterlogger.log(JSON.stringify(clusterdata));
+    this.clusterlogger.log(bloatControl(clusterdata));
   }
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -34,7 +34,7 @@ function respondError(message, status, e, req) {
     status,
     headers,
   });
-  console.error(msg);
+  console.error('Loggable error:', msg, e && e.stack);
   try {
     const c = new CoralogixErrorLogger(req);
     c.logError(status, message);

--- a/src/s3-logger.mjs
+++ b/src/s3-logger.mjs
@@ -11,6 +11,7 @@
  */
 import { Logger } from './logger.mjs';
 import {
+  bloatControl,
   cleanurl,
   getMaskedTime,
   getMaskedUserAgent,
@@ -51,6 +52,6 @@ export class S3Logger {
       ...json,
     };
 
-    this.logger.log(JSON.stringify(data));
+    this.logger.log(bloatControl(data));
   }
 }

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -276,3 +276,38 @@ export function getSubsystem(req) {
   }
   return 'undefined';
 }
+
+/**
+ * Cloudflare applies a 16kb limit to all log messages, so we need to make sure
+ * that the JSON we send to the logger is not too large. This function will
+ * apply a couple of tricks to make this happen
+ * 1. limit the length of any string value to 1024 characters
+ * 2. cast LCP, INP, TTFB to integers
+ * @param {Object} obj an object to be logged
+ * @returns {String} the sanitized object as a JSON string
+ */
+export function bloatControl(obj) {
+  // the object can have nested objects, so we may need recursion
+  const sanitize = (o, k) => {
+    if (typeof o === 'string' && o.length > 1024) {
+      return `${o.substring(0, 1024)}…`;
+    }
+    if (typeof o === 'number') {
+      if (['LCP', 'INP', 'TTFB'].includes(k)) {
+        return Math.floor(o);
+      }
+      return o;
+    }
+    if (Array.isArray(o)) {
+      return o.map(sanitize);
+    }
+    if (typeof o === 'object') {
+      return Object.entries(o).reduce((acc, [key, value]) => {
+        acc[key] = sanitize(value, key);
+        return acc;
+      }, {});
+    }
+    return o;
+  };
+  return JSON.stringify(sanitize(obj));
+}

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -301,7 +301,7 @@ export function bloatControl(obj) {
     if (Array.isArray(o)) {
       return o.map(sanitize);
     }
-    if (typeof o === 'object') {
+    if (typeof o === 'object' && o !== null) {
       return Object.entries(o).reduce((acc, [key, value]) => {
         acc[key] = sanitize(value, key);
         return acc;

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -293,7 +293,7 @@ export function bloatControl(obj) {
       return `${o.substring(0, 1024)}…`;
     }
     if (typeof o === 'number') {
-      if (['LCP', 'INP', 'TTFB'].includes(k)) {
+      if (['LCP', 'INP', 'TTFB', 'time'].includes(k)) {
         return Math.floor(o);
       }
       return o;

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -293,7 +293,7 @@ export function bloatControl(obj) {
       return `${o.substring(0, 1024)}…`;
     }
     if (typeof o === 'number') {
-      if (['LCP', 'INP', 'TTFB', 'time'].includes(k)) {
+      if (['LCP', 'INP', 'TTFB'].includes(k)) {
         return Math.floor(o);
       }
       return o;

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -334,7 +334,7 @@ describe('Test index', () => {
 
     const logged = JSON.parse(lastLogMessage);
     assert.equal(0.06, logged.CLS);
-    assert.equal(1.1, logged.LCP);
+    assert.equal(1, logged.LCP);
     assert.equal(0.9, logged.FCP);
     assert.equal(800, logged.TTFB);
   });

--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -20,9 +20,32 @@ import {
   getSubsystem,
   isValidId,
   maskTime,
+  bloatControl,
 } from '../src/utils.mjs';
 
 describe('Test Utils', () => {
+  it('Bloat control', () => {
+    assert.equal('{}', bloatControl({}));
+    assert.equal('[]', bloatControl([]));
+    assert.equal('{"lorem":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent ac molestie ex. Suspendisse a imperdiet enim. Nulla tempor, tellus volutpat dictum auctor, purus justo consequat felis, sit amet condimentum odio urna ornare dolor. Pellentesque eget ultrices libero. Suspendisse quis diam eu augue consectetur lobortis at et leo. Quisque efficitur sit amet sem id aliquet. In hac habitasse platea dictumst. Maecenas sed orci tincidunt, tempus diam lobortis, egestas nibh. Nulla arcu purus, fermentum vitae augue vel, sodales porttitor arcu. Quisque iaculis porttitor lectus, id rhoncus arcu sollicitudin lobortis.\\n\\nMauris massa leo, feugiat ac congue sit amet, auctor id arcu. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vestibulum hendrerit urna sit amet quam accumsan consequat quis id diam. Morbi scelerisque a diam in mollis. Ut at convallis diam, a accumsan sem. Curabitur molestie sem nec orci mattis, ut convallis metus pellentesque. Morbi vitae erat felis. Curabitur purus n…"}', bloatControl({
+      lorem: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent ac molestie ex. Suspendisse a imperdiet enim. Nulla tempor, tellus volutpat dictum auctor, purus justo consequat felis, sit amet condimentum odio urna ornare dolor. Pellentesque eget ultrices libero. Suspendisse quis diam eu augue consectetur lobortis at et leo. Quisque efficitur sit amet sem id aliquet. In hac habitasse platea dictumst. Maecenas sed orci tincidunt, tempus diam lobortis, egestas nibh. Nulla arcu purus, fermentum vitae augue vel, sodales porttitor arcu. Quisque iaculis porttitor lectus, id rhoncus arcu sollicitudin lobortis.
+
+Mauris massa leo, feugiat ac congue sit amet, auctor id arcu. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vestibulum hendrerit urna sit amet quam accumsan consequat quis id diam. Morbi scelerisque a diam in mollis. Ut at convallis diam, a accumsan sem. Curabitur molestie sem nec orci mattis, ut convallis metus pellentesque. Morbi vitae erat felis. Curabitur purus nulla, tempus non arcu ut, convallis euismod justo. Etiam hendrerit risus ligula, a mattis libero placerat eu. Proin interdum elit quam. In sit amet dictum sapien. Duis tempor vulputate tellus. Nam fermentum ligula a nibh facilisis, et eleifend mi euismod.
+
+Pellentesque viverra id magna vel varius. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec porta quis mauris sit amet aliquet. Duis non nulla sed metus sagittis condimentum. Nam rhoncus, risus et gravida tempus, nibh diam pellentesque tellus, vel accumsan arcu nibh in lorem. Pellentesque eu semper ipsum, ac lacinia ante. Phasellus neque urna, laoreet eu purus id, interdum tristique turpis. Nulla pretium fermentum elit non tristique. Aliquam ut orci elit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed a pulvinar urna. Nunc vel augue ultrices, aliquet sapien eget, ornare sem. Etiam sagittis porttitor arcu vitae tristique. Praesent tempus neque ac vehicula viverra. Donec justo nibh, faucibus a rhoncus nec.`,
+    }));
+
+    assert.equal('{"LCP":1234,"INP":2345,"CLS":0.789,"TTFB":1234}', bloatControl({
+      LCP: 1234.5678,
+      INP: 2345.6789,
+      CLS: 0.7890,
+      TTFB: 1234.5678,
+    }));
+
+    // what is neither a string nor a number nor an array nor an object gets stringified as is
+    assert.equal('true', bloatControl(true));
+  });
+
   it('Mask the time', () => {
     const now = Date.now();
     const nearestHour = Math.floor(now / 3600000) * 3600000;


### PR DESCRIPTION
Cloudflare truncates all log messages that exceed 16kb. This should normally not be a problem,
but in some cases we have seen truncation messages. This PR will apply a couple of tweaks to
the logged JSON object to keep size in check:
1. limit all string properties to 1024 characters
2. cast most CWVs to integers, as we don't need the fake accuracy nor the floating point length mismatches

- **feat(utils): add bloat control utility to ensure JSON strings don't get too long**
- **feat(logger): control bloat of JSON logs for Cloudflare**
