### PR TITLE
Remove FID (outdated CWV)

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -163,6 +163,13 @@ export async function main(req, ctx) {
       return respondError('cwv must be an object', 400, undefined, req);
     }
 
+    // Remove any properties that aren't allowed metrics
+    Object.keys(cwv).forEach((key) => {
+      if (!['LCP', 'INP', 'CLS', 'TTFB'].includes(key)) {
+        delete cwv[key];
+      }
+    });
+
     try {
       if (ctx?.runtime?.name === 'compute-at-edge') {
         const c = new CoralogixLogger(req);

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -89,7 +89,7 @@ describe('Test index', () => {
       "id": "foobar",
       "cwv": {
         "a": "aaa",
-        "b": 123
+        "INP": 123
       },
       "referrer": "http://a.b.c",
       "generation": 42,
@@ -121,8 +121,8 @@ describe('Test index', () => {
     assert.equal(42, logged.generation);
     assert.equal('https://t/', logged.target);
     assert.equal('1.2.3.4', logged.source);
-    assert.equal('aaa', logged.a);
-    assert.equal(123, logged.b);
+    assert.equal(undefined, logged.a);
+    assert.equal(123, logged.INP);
     assert.equal('www.foobar.com', logged.host);
     assert.equal('mobile', logged.user_agent);
   });

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -316,7 +316,7 @@ describe('Test index', () => {
       "cwv": {
         "CLS": 0.06,
         "LCP": 1.1,
-        "FCP": 0.9,
+        "INP": 90,
         "TTFB": 800
       },
       "checkpoint": "cwv",
@@ -335,7 +335,7 @@ describe('Test index', () => {
     const logged = JSON.parse(lastLogMessage);
     assert.equal(0.06, logged.CLS);
     assert.equal(1, logged.LCP);
-    assert.equal(0.9, logged.FCP);
+    assert.equal(90, logged.INP);
     assert.equal(800, logged.TTFB);
   });
 


### PR DESCRIPTION
FID has been removed as a Core Web Vital in April, this PR removes our ability to store it, even when posted

- **fix(cwv): remove deprecated FID**
- **test(index): do not expect invalid CWV values to come through anymore**

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
