### PR TITLE
feat: additional bot classification and adjust devicetype fallback

### DIFF
--- a/src/bots.mjs
+++ b/src/bots.mjs
@@ -69,6 +69,10 @@ export const bots = {
       user_agent: 'SiteCheck-sitecrawl by Siteimprove.com',
       regex: 'Siteimprove',
     },
+    {
+      user_agent: 'Chrome Lighthouse',
+      regex: 'chrome-lighthouse',
+    },
   ],
   Monitoring: [
     {
@@ -183,6 +187,10 @@ export const bots = {
       user_agent: 'DeepCrawl',
       regex: 'https://deepcrawl.com/bot',
     },
+    {
+      user_agent: 'OnCrawl',
+      regex: 'http://www.oncrawl.com',
+    },
   ],
   // There is some overlap between AI and Search, and some companies like Apple,
   // Google, and Meta have many bots that are used for different purposes.
@@ -272,6 +280,18 @@ export const bots = {
     {
       user_agent: 'PetalBot',
       regex: 'PetalBot',
+    },
+    {
+      user_agent: '360spider',
+      regex: '360spider',
+    },
+    {
+      user_agent: 'yisouspider',
+      regex: 'yisouspider',
+    },
+    {
+      user_agent: 'ev-crawler',
+      regex: 'ev-crawler',
     },
   ],
   Security: [

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -243,9 +243,13 @@ export function getMaskedUserAgent(headers) {
     const mobileOS = getMobileOS(lcUA);
     return `mobile${mobileOS}${mobileOS ? getBrowserEngine(lcUA) : ''}`;
   }
+  if (lcUA.includes('mozilla')
+    || lcUA.includes('opera')) {
+    const desktopOS = getDesktopOS(lcUA);
+    return `desktop${desktopOS}${desktopOS ? getBrowserEngine(lcUA) : ''}`;
+  }
 
-  const desktopOS = getDesktopOS(lcUA);
-  return `desktop${desktopOS}${desktopOS ? getBrowserEngine(lcUA) : ''}`;
+  return 'undefined';
 }
 
 function cleanJWT(str) {

--- a/test/coralogix-error-logger.test.mjs
+++ b/test/coralogix-error-logger.test.mjs
@@ -40,6 +40,6 @@ describe('Test Coralogix Error Logger', () => {
     assert.equal('http://www.foo.com/blah', loggedJSON.edgecompute.url);
     assert.equal('http://www.foo.com/blah', loggedJSON.cdn.url);
     assert.equal('POST', loggedJSON.request.method);
-    assert.equal('desktop', loggedJSON.request.user_agent);
+    assert.equal('undefined', loggedJSON.request.user_agent);
   });
 });

--- a/test/fixtures/user-agents.json
+++ b/test/fixtures/user-agents.json
@@ -333,5 +333,25 @@
     "desc": "Windows desktop",
     "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0",
     "expected": "desktop:windows:blink"
+  },
+  {
+    "desc": "Opera desktop",
+    "ua": "Opera/12.0(Windows NT 5.2;U;en)Presto/22.9.168 Version/12.00",
+    "expected": "desktop:windows:presto"
+  },
+  {
+    "desc": "Empty",
+    "ua": "",
+    "expected": "undefined"
+  },
+  {
+    "desc": "Java",
+    "ua": "Java/1.8.0-262",
+    "expected": "undefined"
+  },
+  {
+    "desc": "Windows desktop",
+    "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0",
+    "expected": "desktop:windows:gecko"
   }
 ]

--- a/test/fixtures/user-agents.json
+++ b/test/fixtures/user-agents.json
@@ -313,5 +313,25 @@
     "desc": "Twitter",
     "ua": "Mozilla/5.0 (iPad; CPU OS 15_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/19H12 Twitter for iPhone/10.34",
     "expected": "mobile:ipados:webkit"
+  },
+  {
+    "desc": "OnCrawl",
+    "ua": "mozilla/5.0 (compatible; brightedgeoncrawl/1.0; +http://www.oncrawl.com)",
+    "expected": "bot:seo"
+  },
+  {
+    "desc": "ev-crawler",
+    "ua": "mozilla/5.0 (compatible; ev-crawler/1.0; +https://headline.com/legal/crawler)",
+    "expected": "bot:search"
+  },
+  {
+    "desc": "Adobe CCXProcess",
+    "ua": "Adobe CCXProcess-6.1.0-9/win32-10.0.19045-x64",
+    "expected": "undefined"
+  },
+  {
+    "desc": "Windows desktop",
+    "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0",
+    "expected": "desktop:windows:blink"
   }
 ]

--- a/test/fixtures/user-agents.json
+++ b/test/fixtures/user-agents.json
@@ -345,11 +345,6 @@
     "expected": "undefined"
   },
   {
-    "desc": "Java",
-    "ua": "Java/1.8.0-262",
-    "expected": "undefined"
-  },
-  {
     "desc": "Windows desktop",
     "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0",
     "expected": "desktop:windows:gecko"

--- a/test/google-logger.test.mjs
+++ b/test/google-logger.test.mjs
@@ -78,7 +78,7 @@ describe('Test Google Logger', () => {
     const logged = JSON.parse(lastLogMessage);
     assert.equal('a_host', logged.host);
     assert.equal('not_a_url', logged.url);
-    assert.equal('desktop', logged.user_agent);
+    assert.equal('undefined', logged.user_agent);
     assert.equal('http://somehost.com/somepage.html', logged.referer);
     assert.equal(10, logged.weight);
     assert.equal(49, logged.generation);


### PR DESCRIPTION
Two adjustments:

1. added more classification precision (ie. `bot:search` instead of `bot`) to a handful of somewhat frequent user agents
2. changed the fallback device type classification from `desktop` to `undefined` 
