### PR TITLE
fix(headers): cache-control header should never return null

### DIFF
--- a/src/jsdelivr.mjs
+++ b/src/jsdelivr.mjs
@@ -13,6 +13,7 @@
 import { cleanupResponse, prohibitDirectoryRequest } from './cdnutils.mjs';
 
 const redirectHeaders = [301, 302, 307, 308];
+const rangeChars = ['^', '~'];
 
 export async function respondJsdelivr(req) {
   const url = new URL(req.url);
@@ -24,6 +25,13 @@ export async function respondJsdelivr(req) {
     backend: 'jsdelivr',
   });
   console.log('fetched', bereq.url, beresp.status, beresp.headers.get('ETag'), beresp.headers.get('Content-Length'));
+
+  const ccMap = new Map();
+  ccMap.set('x-rum-trace', 'be-j'); // Trace the backend used
+  if (rangeChars.find((char) => decodeURI(beurl.href).includes(char))) {
+    // If the URL contains a range character, set cache-control to 1 hour
+    ccMap.set('cache-control', 'public, max-age=3600');
+  }
 
   if (redirectHeaders.includes(beresp.status)) {
     const bereq2 = new Request(new URL(beresp.headers.get('location'), 'https://cdn.jsdelivr.net'));
@@ -37,9 +45,6 @@ export async function respondJsdelivr(req) {
     });
     console.log('fetched', bereq2.url, beresp2.status, beresp2.headers.get('ETag'), beresp2.headers.get('Content-Length'));
 
-    // override the cache control header
-    beresp2.headers.set('cache-control', beresp.headers.get('cache-control'));
-
     if (redirectHeaders.includes(beresp2.status)) {
       const bereq3 = new Request(new URL(beresp2.headers.get('location'), 'https://cdn.jsdelivr.net'));
       const err3 = prohibitDirectoryRequest(bereq3);
@@ -52,12 +57,9 @@ export async function respondJsdelivr(req) {
       });
       console.log('fetched', bereq3.url, beresp3.status, beresp3.headers.get('ETag'), beresp3.headers.get('Content-Length'));
 
-      // override the cache control header
-      beresp3.headers.set('cache-control', beresp.headers.get('cache-control'));
-
-      return cleanupResponse(beresp3, req);
+      return cleanupResponse(beresp3, req, ccMap);
     }
-    return cleanupResponse(beresp2, req);
+    return cleanupResponse(beresp2, req, ccMap);
   }
-  return cleanupResponse(beresp, req);
+  return cleanupResponse(beresp, req, ccMap);
 }

--- a/src/unpkg.mjs
+++ b/src/unpkg.mjs
@@ -14,6 +14,7 @@
 import { cleanupResponse, prohibitDirectoryRequest } from './cdnutils.mjs';
 
 const redirectHeaders = [301, 302, 307, 308];
+const rangeChars = ['^', '~'];
 
 export async function respondUnpkg(req) {
   const url = new URL(req.url);
@@ -23,6 +24,14 @@ export async function respondUnpkg(req) {
   const beresp = await fetch(bereq, {
     backend: 'unpkg.com',
   });
+
+  const ccMap = new Map();
+  ccMap.set('x-rum-trace', 'be-u'); // Trace the backend used
+  if (rangeChars.find((char) => decodeURI(beurl.href).includes(char))) {
+    // If the URL contains a range character, set cache-control to 1 hour
+    ccMap.set('cache-control', 'public, max-age=3600');
+  }
+
   if (redirectHeaders.includes(beresp.status)) {
     const bereq2 = new Request(new URL(beresp.headers.get('location'), 'https://unpkg.com'));
     const err2 = prohibitDirectoryRequest(bereq2);
@@ -32,9 +41,6 @@ export async function respondUnpkg(req) {
     const beresp2 = await fetch(bereq2, {
       backend: 'unpkg.com',
     });
-
-    // override the cache control header
-    beresp2.headers.set('cache-control', beresp.headers.get('cache-control'));
 
     if (redirectHeaders.includes(beresp2.status)) {
       const bereq3 = new Request(new URL(beresp2.headers.get('location'), 'https://unpkg.com'));
@@ -47,12 +53,9 @@ export async function respondUnpkg(req) {
         backend: 'unpkg.com',
       });
 
-      // override the cache control header
-      beresp3.headers.set('cache-control', beresp.headers.get('cache-control'));
-
-      return cleanupResponse(beresp3, req);
+      return cleanupResponse(beresp3, req, ccMap);
     }
-    return cleanupResponse(beresp2, req);
+    return cleanupResponse(beresp2, req, ccMap);
   }
-  return cleanupResponse(beresp, req);
+  return cleanupResponse(beresp, req, ccMap);
 }

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -226,7 +226,6 @@ describe('Test index', () => {
 
     assert.equal(200, resp.status);
     assert(resp.ok);
-    assert(resp.headers.has('etag'));
     assert(!resp.headers.has('server'));
     assert(!resp.headers.has('cf-cache-status'));
     assert(!resp.headers.has('cr-ray'));

--- a/test/jsdelivr.test.mjs
+++ b/test/jsdelivr.test.mjs
@@ -43,6 +43,11 @@ describe('Test jdelivr handler', () => {
       assert.equal(200, resp.status);
       assert.equal('abc', resp.headers.get('xyz'));
       assert.equal('cross-origin', resp.headers.get('Cross-Origin-Resource-Policy'));
+      assert.equal(
+        'public, max-age=3600',
+        resp.headers.get('cache-control'),
+        'If not set, cache-control should default to 1 hour',
+      );
     } finally {
       global.fetch = storedFetch;
     }
@@ -231,6 +236,91 @@ describe('Test jdelivr handler', () => {
       const resp = await respondJsdelivr(req);
       assert.equal(404, resp.status);
       assert.deepStrictEqual(['a', 'b'], redirectsMade, 'Expected two redirects to be made by the test');
+    } finally {
+      global.fetch = storedFetch;
+    }
+  });
+
+  it('sets cache-control to 1 hour if the URL contains a range character', async () => {
+    const req = {
+      url: 'https://foo.bar.org/.rum/@adobe/helix-rum-enhancer@%5E2/src/index.js',
+    };
+
+    const storedFetch = global.fetch;
+    try {
+      // Mock the global fetch function
+      global.fetch = (v) => {
+        const resp = {
+          url: v.url,
+          status: 200,
+        };
+        resp.headers = new Headers();
+        return resp;
+      };
+
+      const resp = await respondJsdelivr(req);
+      assert.equal(200, resp.status);
+      assert.equal('public, max-age=3600', resp.headers.get('cache-control'));
+    } finally {
+      global.fetch = storedFetch;
+    }
+  });
+
+  it('forces cache-control to 1 hour if the URL contains a range character', async () => {
+    const req = {
+      url: 'https://foo.bar.org/.rum/@adobe/helix-rum-enhancer@~2/src/index.js',
+    };
+
+    const storedFetch = global.fetch;
+    try {
+      // Mock the global fetch function
+      global.fetch = (v) => {
+        const resp = {
+          url: v.url,
+          status: 200,
+        };
+        resp.headers = new Headers();
+        resp.headers.set('cache-control', 'max-age=999999999');
+        resp.headers.set('content-type', 'application/javascript; charset=utf-8');
+        return resp;
+      };
+
+      const resp = await respondJsdelivr(req);
+      assert.equal(200, resp.status);
+      assert.equal('text/javascript; charset=utf-8', resp.headers.get('content-type'));
+      assert.equal(
+        'public, max-age=3600',
+        resp.headers.get('cache-control'),
+        'Should have overridden the cache control header on range request',
+      );
+    } finally {
+      global.fetch = storedFetch;
+    }
+  });
+
+  it('keeps original cache-control for specific version requests', async () => {
+    const req = {
+      url: 'https://foo.bar.org/.rum/@adobe/helix-rum-enhancer@2.33.0/src/index.js',
+    };
+
+    const storedFetch = global.fetch;
+    try {
+      // Mock the global fetch function
+      global.fetch = (v) => {
+        const resp = {
+          url: v.url,
+          status: 200,
+        };
+        resp.headers = new Headers();
+        resp.headers.set('cache-control', 'max-age=999999999');
+        resp.headers.set('content-type', 'text/javascript');
+        return resp;
+      };
+
+      const resp = await respondJsdelivr(req);
+      assert.equal(200, resp.status);
+      assert.equal('text/javascript', resp.headers.get('content-type'));
+      assert.equal('max-age=999999999', resp.headers.get('cache-control'));
     } finally {
       global.fetch = storedFetch;
     }

--- a/test/post-deploy.test.mjs
+++ b/test/post-deploy.test.mjs
@@ -147,7 +147,7 @@ import assert from 'assert';
       });
       assert.strictEqual(response.status, 200);
       // eslint-disable-next-line no-unused-expressions
-      assert.match(response.headers.get('content-type'), /^application\/javascript/);
+      assert.match(response.headers.get('content-type'), /^text\/javascript/);
     });
 
     it('web vitals module is being served without redirect', async function test() {
@@ -159,7 +159,7 @@ import assert from 'assert';
       });
       assert.strictEqual(response.status, 200);
       // eslint-disable-next-line no-unused-expressions
-      assert.match(response.headers.get('content-type'), /^application\/javascript/);
+      assert.match(response.headers.get('content-type'), /^text\/javascript/);
     });
 
     it('rum js module is being served without redirect', async function test() {
@@ -171,7 +171,7 @@ import assert from 'assert';
       });
       assert.strictEqual(response.status, 200);
       // eslint-disable-next-line no-unused-expressions
-      assert.match(response.headers.get('content-type'), /^application\/javascript/);
+      assert.match(response.headers.get('content-type'), /^text\/javascript/);
     });
 
     it('rum js module is served with compression', async function test() {
@@ -186,8 +186,26 @@ import assert from 'assert';
       });
       assert.strictEqual(response.status, 200);
       // eslint-disable-next-line no-unused-expressions
-      assert.match(response.headers.get('content-type'), /^application\/javascript/);
+      assert.match(response.headers.get('content-type'), /^text\/javascript/);
       assert.match(response.headers.get('content-encoding'), /^(br|gzip|deflate)$/);
+    });
+
+    it('rum enhancer is served with the correct cache-control', async function test() {
+      if (!process.env.TEST_INTEGRATION) {
+        this.skip();
+      }
+
+      const respRange = await fetch(`https://${domain}/.rum/@adobe/helix-rum-enhancer@%5E2/src/index.js`);
+      assert.strictEqual(respRange.status, 200);
+      const ccHeader = respRange.headers.get('cache-control').split(',');
+      assert(ccHeader.find((header) => header.trim() === 'max-age=3600'), 'Should have a max cache age of 3600');
+
+      const respSpecific = await fetch(`https://${domain}/.rum/@adobe/helix-rum-enhancer@2.33.0/src/index.js`);
+      assert.strictEqual(respSpecific.status, 200);
+      const ccHeaderSp = respSpecific.headers.get('cache-control').split(',');
+      const maHeader = ccHeaderSp.find((header) => header.trim().startsWith('max-age='));
+      const maxAge = Number(maHeader.split('=')[1]);
+      assert(maxAge > 3600, 'Should have a max cache age greater than 3600');
     });
 
     it.skip('rum js module is being served with default replacements', async function test() {
@@ -199,7 +217,7 @@ import assert from 'assert';
       });
       assert.strictEqual(response.status, 200);
       // eslint-disable-next-line no-unused-expressions
-      assert.match(response.headers.get('content-type'), /^application\/javascript/);
+      assert.match(response.headers.get('content-type'), /^text\/javascript/);
       const text = await response.text();
       assert.include(text, 'adobe-helix-rum-js-1.0.0');
     });


### PR DESCRIPTION
## Related Issues

Fixes: #483

Also ensures that `content-type: text/javascript` is always returned when serving javascript.