### PR TITLE
feat(security): add X-Frame-Options header to responses

### DIFF
--- a/src/cdnutils.mjs
+++ b/src/cdnutils.mjs
@@ -63,6 +63,7 @@ export function cleanupHeaders(resp, addHeaders) {
   }
 
   newHeaders.set('Cross-Origin-Resource-Policy', 'cross-origin');
+  newHeaders.set('X-Frame-Options', 'DENY');
   newHeaders.set('x-compress-hint', 'on');
 
   const result = new Response(resp.body, {
@@ -103,6 +104,7 @@ export async function cleanupResponse(resp, req, newHeaders) {
       status: resp.status,
       headers: {
         'Content-Type': 'text/plain',
+        'X-Frame-Options': 'DENY',
         'x-error': `Error: ${resp.status} from backend`,
       },
     });
@@ -114,7 +116,14 @@ export async function cleanupResponse(resp, req, newHeaders) {
 
 export function prohibitDirectoryRequest(req) {
   if (req?.url.endsWith('/')) {
-    return new Response('Directory listing is not permitted', { status: 404 });
+    return new Response('Directory listing is not permitted', {
+      status: 404,
+      headers: {
+        'Content-Type': 'text/plain',
+        'x-error': 'Error: Directory listing is not permitted',
+        'X-Frame-Options': 'DENY',
+      },
+    });
   }
   return undefined;
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -24,10 +24,11 @@ import { respondUnpkg } from './unpkg.mjs';
 const REGISTRY_TIMEOUT_MS = 5000;
 
 function respondError(message, status, e, req) {
+  const msg = e && e.message ? `${message}: ${e.message}` : message;
   const headers = {
     'Content-Type': 'text/plain; charset=utf-8',
     'X-Frame-Options': 'DENY',
-    'X-Error': e && e.message ? `${message}: ${e.message}` : message,
+    'X-Error': msg,
   };
 
   const response = new Response(`${msg}\n`, {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -24,11 +24,11 @@ import { respondUnpkg } from './unpkg.mjs';
 const REGISTRY_TIMEOUT_MS = 5000;
 
 function respondError(message, status, e, req) {
-  const headers = new Headers();
-  const msg = e && e.message ? `${message}: ${e.message}` : message;
-
-  headers.set('Content-Type', 'text/plain; charset=utf-8');
-  headers.set('X-Error', msg);
+  const headers = {
+    'Content-Type': 'text/plain; charset=utf-8',
+    'X-Frame-Options': 'DENY',
+    'X-Error': e && e.message ? `${message}: ${e.message}` : message,
+  };
 
   const response = new Response(`${msg}\n`, {
     status,
@@ -49,7 +49,12 @@ function getRandomID() {
 }
 
 function respondInfo(ctx) {
-  return new Response(`{"platform": "${ctx?.runtime?.name}", "version": "${ctx?.func?.version}"}`);
+  return new Response(`{"platform": "${ctx?.runtime?.name}", "version": "${ctx?.func?.version}"}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Frame-Options': 'DENY',
+    },
+  });
 }
 
 export function respondCORS() {
@@ -58,6 +63,7 @@ export function respondCORS() {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type',
+      'X-Frame-Options': 'DENY',
     },
   });
 }
@@ -110,7 +116,13 @@ async function respondPackage(req) {
       respondRegistry('unpkg', req, successTracker, unpkgDelay),
     ]);
   } catch (error) {
-    return new Response(error.errors, { status: 500 });
+    return new Response(error.errors, {
+      status: 500,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'X-Frame-Options': 'DENY',
+      },
+    });
   }
 }
 
@@ -157,9 +169,11 @@ export async function main(req, ctx) {
       ? JSON.parse(new URL(req.url).searchParams.get('data'))
       : await req.json();
 
-    const headers = new Headers();
-    headers.set('Content-Type', 'text/plain; charset=utf-8');
-    headers.set('Cross-Origin-Resource-Policy', 'cross-origin');
+    const headers = {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cross-Origin-Resource-Policy': 'cross-origin',
+      'X-Frame-Options': 'DENY',
+    };
 
     const {
       weight = 1,

--- a/src/robots.mjs
+++ b/src/robots.mjs
@@ -15,7 +15,8 @@ export function respondRobots() {
 User-agent: *
 Disallow: /`, {
     headers: {
-      'content-type': 'text/plain',
+    'Content-Type': 'text/plain',
+    'X-Frame-Options': 'DENY',
     },
   });
 }

--- a/src/robots.mjs
+++ b/src/robots.mjs
@@ -15,8 +15,8 @@ export function respondRobots() {
 User-agent: *
 Disallow: /`, {
     headers: {
-    'Content-Type': 'text/plain',
-    'X-Frame-Options': 'DENY',
+      'Content-Type': 'text/plain',
+      'X-Frame-Options': 'DENY',
     },
   });
 }

--- a/test/post-deploy.test.mjs
+++ b/test/post-deploy.test.mjs
@@ -36,6 +36,7 @@ import assert from 'assert';
         method: 'POST',
       });
       assert.strictEqual(response.status, 400);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('RUM collection with masked timestamp (t) returns 201', async function test() {
@@ -59,6 +60,7 @@ import assert from 'assert';
         }),
       });
       assert.strictEqual(response.status, 201);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('RUM collection returns 201', async function test() {
@@ -81,6 +83,7 @@ import assert from 'assert';
         }),
       });
       assert.strictEqual(response.status, 201);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('RUM collection with empty string id returns 201', async function test() {
@@ -103,6 +106,7 @@ import assert from 'assert';
         }),
       });
       assert.strictEqual(response.status, 201);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('RUM collection via GET returns 201', async function test() {
@@ -113,6 +117,7 @@ import assert from 'assert';
         method: 'GET',
       });
       assert.strictEqual(response.status, 201);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('CORS headers are set', async function test() {
@@ -124,6 +129,7 @@ import assert from 'assert';
       });
       assert.strictEqual(response.status, 200);
       assert.strictEqual(response.headers.get('access-control-allow-origin'), '*');
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('robots.txt denies everything', async function test() {
@@ -136,6 +142,7 @@ import assert from 'assert';
       assert.strictEqual(response.status, 200);
       // eslint-disable-next-line no-unused-expressions
       assert.strictEqual(response.headers.get('content-type'), 'text/plain');
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('web vitals module is being served', async function test() {
@@ -148,6 +155,7 @@ import assert from 'assert';
       assert.strictEqual(response.status, 200);
       // eslint-disable-next-line no-unused-expressions
       assert.match(response.headers.get('content-type'), /^text\/javascript/);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('web vitals module is being served without redirect', async function test() {
@@ -160,6 +168,7 @@ import assert from 'assert';
       assert.strictEqual(response.status, 200);
       // eslint-disable-next-line no-unused-expressions
       assert.match(response.headers.get('content-type'), /^text\/javascript/);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('rum js module is being served without redirect', async function test() {
@@ -172,6 +181,7 @@ import assert from 'assert';
       assert.strictEqual(response.status, 200);
       // eslint-disable-next-line no-unused-expressions
       assert.match(response.headers.get('content-type'), /^text\/javascript/);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('rum js module is served with compression', async function test() {
@@ -188,6 +198,7 @@ import assert from 'assert';
       // eslint-disable-next-line no-unused-expressions
       assert.match(response.headers.get('content-type'), /^text\/javascript/);
       assert.match(response.headers.get('content-encoding'), /^(br|gzip|deflate)$/);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('rum enhancer is served with the correct cache-control', async function test() {
@@ -199,6 +210,7 @@ import assert from 'assert';
       assert.strictEqual(respRange.status, 200);
       const ccHeader = respRange.headers.get('cache-control').split(',');
       assert(ccHeader.find((header) => header.trim() === 'max-age=3600'), 'Should have a max cache age of 3600');
+      assert.strictEqual(respRange.headers.get('x-frame-options'), 'DENY');
 
       const respSpecific = await fetch(`https://${domain}/.rum/@adobe/helix-rum-enhancer@2.33.0/src/index.js`);
       assert.strictEqual(respSpecific.status, 200);
@@ -206,6 +218,7 @@ import assert from 'assert';
       const maHeader = ccHeaderSp.find((header) => header.trim().startsWith('max-age='));
       const maxAge = Number(maHeader.split('=')[1]);
       assert(maxAge > 3600, 'Should have a max cache age greater than 3600');
+      assert.strictEqual(respSpecific.headers.get('x-frame-options'), 'DENY');
     });
 
     it.skip('rum js module is being served with default replacements', async function test() {
@@ -220,6 +233,7 @@ import assert from 'assert';
       assert.match(response.headers.get('content-type'), /^text\/javascript/);
       const text = await response.text();
       assert.include(text, 'adobe-helix-rum-js-1.0.0');
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('Missing id returns 400', async function test() {
@@ -241,6 +255,7 @@ import assert from 'assert';
         }),
       });
       assert.strictEqual(response.status, 400);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('Non-numeric weight returns 400', async function test() {
@@ -263,6 +278,7 @@ import assert from 'assert';
         }),
       });
       assert.strictEqual(response.status, 400);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('Non-object root returns 400', async function test() {
@@ -277,6 +293,7 @@ import assert from 'assert';
         body: JSON.stringify([]),
       });
       assert.strictEqual(response.status, 400);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('Sensitive files return 404 - package.json', async function test() {
@@ -290,6 +307,7 @@ import assert from 'assert';
       assert.strictEqual(response.status, 404, `Expected 404 for ${url}`);
       const text = await response.text();
       assert.match(text, /Not Found/);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('Sensitive files return 404 - CHANGELOG.md', async function test() {
@@ -303,6 +321,7 @@ import assert from 'assert';
       assert.strictEqual(response.status, 404, `Expected 404 for ${url}`);
       const text = await response.text();
       assert.match(text, /Not Found/);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
     });
 
     it('Reject paths that are double-encoded', async function test() {
@@ -314,6 +333,7 @@ import assert from 'assert';
       assert.strictEqual(resp.status, 400);
       const respTxt = await resp.text();
       assert(respTxt.startsWith('Invalid path'));
+      assert.strictEqual(resp.headers.get('x-frame-options'), 'DENY');
     });
 
     it('Reject paths that contain partially encoded ".."', async function test() {
@@ -325,6 +345,7 @@ import assert from 'assert';
       assert.strictEqual(resp.status, 400);
       const respTxt = await resp.text();
       assert(respTxt.startsWith('Invalid path'));
+      assert.strictEqual(resp.headers.get('x-frame-options'), 'DENY');
     });
 
     it('Non-existent files in .rum directory return 404', async function test() {
@@ -335,6 +356,7 @@ import assert from 'assert';
       const resp = await fetch(`https://${domain}/.rum/@adobe/helix-rum-js@%5E2/dist/rum-standalone.js/favicon.ico`);
       const respTxt = await resp.text();
       assert.strictEqual(resp.status, 404, `Expected 404 but got ${resp.status}. Response body: ${respTxt}`);
+      assert.strictEqual(resp.headers.get('x-frame-options'), 'DENY');
     });
   });
 });


### PR DESCRIPTION
This update introduces the 'X-Frame-Options' header set to 'DENY' across various response functions to enhance security by preventing clickjacking attacks. The header is added to cleanupHeaders, cleanupResponse, prohibitDirectoryRequest, respondError, respondInfo, respondCORS, and robots.txt responses. Additionally, tests have been updated to verify the presence of this header in responses.
As none of the resources served by this service are of type text/html, there is no actual risk of click-jacking, so the addition of this header only serves the purpose of reducing the number of false-positive reports generated by overly simplistic security scanning software and their ill-configured reporting rules.
