### PR TITLE
feat: add Do Not Track (DNT) functionality

### DIFF
--- a/src/dnt.mjs
+++ b/src/dnt.mjs
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Responds with a machine-readable DNT status resource
+ * According to W3C Tracking Preference Expression (DNT) spec:
+ * https://www.w3.org/TR/tracking-dnt/
+ *
+ * @param {Request} req The request object
+ * @returns {Response} The response object with DNT tracking status
+ */
+export function respondDNTStatus(req) {
+  const headers = {
+    'Content-Type': 'application/tracking-status+json',
+    'Cache-Control': 'max-age=604800',
+    'X-Frame-Options': 'DENY',
+    Tk: 'N',
+  };
+
+  // Extract the origin from the request URL
+  const url = new URL(req.url);
+  const { origin } = url;
+
+  // Our tracking status object as per section 7.5 of the spec
+  const trackingStatus = {
+    tracking: 'N', // N = Not tracking
+    policy: `${origin}/.well-known/dnt-policy.txt`,
+    qualifiers: ['sfd'], // security, financial, debugging
+    controller: ['https://www.adobe.com/privacy.html'],
+    compliance: ['https://www.w3.org/TR/tracking-dnt/'],
+  };
+
+  return new Response(JSON.stringify(trackingStatus, null, 2), {
+    status: 200,
+    headers,
+  });
+}
+
+/**
+ * Responds with a human-readable DNT policy
+ *
+ * @param {Request} req The request object
+ * @returns {Response} The response object with human-readable DNT policy
+ */
+export function respondDNTPolicy(req) {
+  // Extract the origin from the request URL
+  const url = new URL(req.url);
+  const { origin } = url;
+
+  const headers = {
+    'Content-Type': 'text/plain',
+    'Cache-Control': 'max-age=604800',
+    'X-Frame-Options': 'DENY',
+    Tk: 'N',
+  };
+
+  const policy = `Operational Telemetry - Do Not Track Policy
+Do Not Track Compliance Policy
+
+Version 1.0
+
+This domain complies with user opt-outs from tracking via the "Do Not Track"
+or "DNT" header  [http://www.w3.org/TR/tracking-dnt/].  This file will always
+be posted via HTTPS at ${origin}/.well-known/dnt-policy.txt
+to indicate this fact.
+
+PRIVACY COMMITMENT
+-----------------
+Adobe Experience Manager's Operational Telemetry Collector is designed to preserve visitor privacy
+and minimize data collection. We are committed to respecting Do Not Track (DNT) preferences.
+
+DATA COLLECTION
+--------------
+Our Operational Telemetry:
+- Only captures information from a small fraction of page views (sampling)
+- Has no concept of visitors, visits, or sessions - only individual checkpoints during a page view
+- Does not use any client-side state or ID (such as cookies or localStorage)
+- Does not perform "fingerprinting" of devices or individuals
+
+COLLECTED DATA
+-------------
+When DNT is not enabled, the limited data we collect may include:
+- The host name of the site being visited
+- The host name of the data collection server
+- A simplified device class identifier (not the full user agent string)
+- Rounded timestamp (to preserve privacy)
+- URL of page visited (without URL parameters)
+- Referrer URL (without URL parameters)
+- A randomly generated page view ID
+- The weight or inverse of the sampling rate
+- Checkpoint names during page loading
+- Source and target of interaction events
+- Core Web Vitals performance metrics (LCP, INP, CLS, TTFB)
+
+DATA USAGE
+---------
+The collected data is only used for:
+- Identifying and fixing performance bottlenecks
+- Estimating page view numbers
+- Understanding compatibility with other scripts
+
+PRIVACY PROTECTION
+----------------
+Our Operational Telemetry is designed to prevent:
+1. Identification of individual visitors or devices
+2. Fingerprinting
+3. Tracking of visits or sessions
+4. Enrichment with personally identifiable information
+
+For privacy-related inquiries, please contact privacy@adobe.com
+
+---
+
+Last updated: 2025-04-16`;
+
+  return new Response(policy, {
+    status: 200,
+    headers,
+  });
+}

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -20,6 +20,7 @@ import { S3Logger } from './s3-logger.mjs';
 import { respondRobots } from './robots.mjs';
 import { respondJsdelivr } from './jsdelivr.mjs';
 import { respondUnpkg } from './unpkg.mjs';
+import { respondDNTStatus, respondDNTPolicy } from './dnt.mjs';
 
 const REGISTRY_TIMEOUT_MS = 5000;
 
@@ -133,6 +134,14 @@ export async function main(req, ctx) {
     }
     if (req.method === 'GET' && pathname.startsWith('/info.json')) {
       return respondInfo(ctx);
+    }
+
+    // Handle DNT (Do Not Track) endpoints
+    if (req.method === 'GET' && pathname === '/.well-known/dnt/') {
+      return respondDNTStatus(req);
+    }
+    if (req.method === 'GET' && pathname === '/.well-known/dnt-policy.txt') {
+      return respondDNTPolicy(req);
     }
 
     // Block access to sensitive files

--- a/test/dnt.test.mjs
+++ b/test/dnt.test.mjs
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+import assert from 'assert';
+import { it, describe } from 'node:test';
+
+import { respondDNTStatus, respondDNTPolicy } from '../src/dnt.mjs';
+
+describe('Test DNT resources', () => {
+  it('responds with correct DNT status', async () => {
+    const req = {
+      url: 'https://example.com/.well-known/dnt/',
+    };
+
+    const resp = await respondDNTStatus(req);
+    assert.equal(200, resp.status);
+    assert.equal('application/tracking-status+json', resp.headers.get('Content-Type'));
+
+    // Verify the response is valid JSON
+    const data = await resp.json();
+    assert.equal('N', data.tracking); // Verify tracking status is 'Not tracking'
+    assert(data.compliance && data.compliance.includes('https://www.w3.org/TR/tracking-dnt/'));
+  });
+
+  it('responds with correct DNT policy', async () => {
+    const req = {
+      url: 'https://example.com/.well-known/dnt-policy.txt',
+    };
+
+    const resp = await respondDNTPolicy(req);
+    assert.equal(200, resp.status);
+    assert.equal('text/plain', resp.headers.get('Content-Type'));
+
+    // Verify the response is a string containing the policy text
+    const text = await resp.text();
+    assert(text.includes('Do Not Track Compliance Policy'));
+  });
+});

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -172,6 +172,32 @@ describe('Test index', () => {
     assert(t.includes('Disallow: /'));
   });
 
+  it('responds to /.well-known/dnt/ endpoint', async () => {
+    const headers = new Map();
+
+    const req = { headers };
+    req.method = 'GET';
+    req.url = 'http://x.y/.well-known/dnt/';
+
+    const resp = await methods.main(req);
+    assert.equal(200, resp.status);
+    assert.equal('application/tracking-status+json', resp.headers.get('Content-Type'));
+    assert.equal('N', resp.headers.get('Tk')); // Check Tk header is set to N (Not tracking)
+  });
+
+  it('responds to /.well-known/dnt-policy.txt endpoint', async () => {
+    const headers = new Map();
+
+    const req = { headers };
+    req.method = 'GET';
+    req.url = 'http://x.y/.well-known/dnt-policy.txt';
+
+    const resp = await methods.main(req);
+    assert.equal(200, resp.status);
+    assert.equal('text/plain', resp.headers.get('Content-Type'));
+    assert.equal('N', resp.headers.get('Tk')); // Check Tk header is set to N (Not tracking)
+  });
+
   async function verifyInput(data, errPrefix) {
     const headers = new Map();
 


### PR DESCRIPTION
Introduced new DNT endpoints to respond with machine-readable tracking status and human-readable DNT policy. Implemented the `respondDNTStatus` and `respondDNTPolicy` functions in `dnt.mjs`, and updated the main request handler to route requests to these endpoints. Added tests to ensure correct responses for DNT status and policy.
