### PR TITLE
More privacy filters

### DIFF
--- a/src/console-logger.mjs
+++ b/src/console-logger.mjs
@@ -44,7 +44,7 @@ export class ConsoleLogger {
     const data = {
       time: now,
       host: this.subsystemName,
-      url: referer || (this.req.headers.has('referer') ? this.req.headers.get('referer') : this.req.url),
+      url: cleanurl(referer || (this.req.headers.has('referer') ? this.req.headers.get('referer') : this.req.url)),
       user_agent: getMaskedUserAgent(this.req.headers),
       referer: cleanurl(this.req.headers.get('referer')),
       weight,

--- a/src/google-logger.mjs
+++ b/src/google-logger.mjs
@@ -44,7 +44,7 @@ export class GoogleLogger {
     const data = {
       time: now,
       host: this.subsystemName,
-      url: referer || (this.req.headers.has('referer') ? this.req.headers.get('referer') : this.req.url),
+      url: cleanurl(referer || (this.req.headers.has('referer') ? this.req.headers.get('referer') : this.req.url)),
       user_agent: getMaskedUserAgent(this.req.headers),
       referer: cleanurl(this.req.headers.get('referer')),
       weight,

--- a/src/privacy.js
+++ b/src/privacy.js
@@ -31,13 +31,14 @@ const filters = {
   jwt: withInputValidation((str, replaceWith) => str.replace(/eyJ[a-zA-Z0-9]+\.eyJ[a-zA-Z0-9]+\.[a-zA-Z0-9]+/g, replaceWith)),
 
   pnr: withInputValidation((str, replaceWith) => {
-    // Split the path into segments, preserving leading/trailing slashes
-    const hasLeadingSlash = str.startsWith('/');
-    const hasTrailingSlash = str.endsWith('/');
-    const segments = str.split('/').filter(Boolean);
+    // Split the path into segments, preserving empty segments for slashes
+    const segments = str.split('/');
 
     // Process each segment
     const processedSegments = segments.map((segment) => {
+      // Skip empty segments (these represent slashes)
+      if (!segment) return segment;
+
       // Check if segment matches PNR pattern (5-7 alphanumeric characters)
       const pnrMatch = segment.match(/^([A-Z0-9]{5,7})$/);
 
@@ -76,7 +77,7 @@ const filters = {
     });
 
     // Reconstruct the path with proper slashes
-    return `${hasLeadingSlash ? '/' : ''}${processedSegments.join('/')}${hasTrailingSlash ? '/' : ''}`;
+    return processedSegments.join('/');
   }),
 };
 

--- a/src/privacy.js
+++ b/src/privacy.js
@@ -10,23 +10,81 @@
  * governing permissions and limitations under the License.
  */
 
-const filters = {
-  cleanJWT: (str) => {
-    if (!str || typeof str.replace !== 'function') return str;
-    return str.replace(/eyJ[a-zA-Z0-9]+\.eyJ[a-zA-Z0-9]+\.[a-zA-Z0-9]+/g, '<jwt>');
-  },
+// Helper function to calculate Shannon entropy
+function shannonEntropy(input) {
+  const freq = {};
+  for (const ch of input) freq[ch] = (freq[ch] || 0) + 1;
+  const len = input.length;
+  return Object.values(freq)
+    .reduce((sum, n) => {
+      const p = n / len;
+      return sum - p * Math.log2(p);
+    }, 0);
+}
 
-  cleanCode: (str) => {
-    if (!str || typeof str.replace !== 'function') return str;
-    return str.replace(/(trip\/)[A-Z0-9]{5,7}\/[A-Z]+/, '$1');
-  },
+const withInputValidation = (fn) => (str, replaceWith) => {
+  if (!str || typeof str.replace !== 'function') return str;
+  return fn(str, replaceWith);
+};
+
+const filters = {
+  jwt: withInputValidation((str, replaceWith) => str.replace(/eyJ[a-zA-Z0-9]+\.eyJ[a-zA-Z0-9]+\.[a-zA-Z0-9]+/g, replaceWith)),
+
+  pnr: withInputValidation((str, replaceWith) => {
+    // Split the path into segments, preserving leading/trailing slashes
+    const hasLeadingSlash = str.startsWith('/');
+    const hasTrailingSlash = str.endsWith('/');
+    const segments = str.split('/').filter(Boolean);
+
+    // Process each segment
+    const processedSegments = segments.map((segment) => {
+      // Check if segment matches PNR pattern (5-7 alphanumeric characters)
+      const pnrMatch = segment.match(/^([A-Z0-9]{5,7})$/);
+
+      if (pnrMatch) {
+        const pnr = pnrMatch[0];
+        const entropy = shannonEntropy(pnr);
+        // Calculate linguistic signals
+        // 1. Check vowel ratio to identify pronounceable words like "GAMERS" and "CIRCLE"
+        const vowels = (pnr.match(/[AEIOU]/g) || []).length;
+        const letters = pnr.match(/[A-Z]/g).length;
+        const vowelRatio = vowels / letters;
+
+        // 2. Check for numbers in the middle (common in PNRs but not in words)
+        const hasMiddleNumbers = /[A-Z][0-9]+[A-Z]/.test(pnr);
+
+        // 3. Base threshold we'll adjust
+        let entropyThreshold = 2.2;
+
+        // Adjust threshold based on signals
+        // Higher vowel ratio → increase threshold (less likely to mask)
+        if (vowelRatio >= 0.3) {
+          entropyThreshold += 0.5; // Looks more like an English word, substantial increase
+        }
+
+        // Numbers in middle → decrease threshold (more likely to mask)
+        if (hasMiddleNumbers) {
+          entropyThreshold -= 0.3; // Looks more like a PNR
+        }
+
+        // Apply the dynamically adjusted threshold
+        if (entropy >= entropyThreshold) {
+          return segment.replace(pnr, replaceWith);
+        }
+      }
+      return segment;
+    });
+
+    // Reconstruct the path with proper slashes
+    return `${hasLeadingSlash ? '/' : ''}${processedSegments.join('/')}${hasTrailingSlash ? '/' : ''}`;
+  }),
 };
 
 export function cleanPath(path) {
   if (!path) return path;
 
-  return Object.values(filters).reduce(
-    (result, filter) => filter(result),
+  return Object.entries(filters).reduce(
+    (result, [key, filter]) => filter(result, `<${key}>`),
     path,
   );
 }

--- a/src/privacy.js
+++ b/src/privacy.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const filters = {
+  cleanJWT: (str) => {
+    if (!str || typeof str.replace !== 'function') return str;
+    return str.replace(/eyJ[a-zA-Z0-9]+\.eyJ[a-zA-Z0-9]+\.[a-zA-Z0-9]+/g, '<jwt>');
+  },
+
+  cleanCode: (str) => {
+    if (!str || typeof str.replace !== 'function') return str;
+    return str.replace(/(trip\/)[A-Z0-9]{5,7}\/[A-Z]+/, '$1');
+  },
+};
+
+export function cleanPath(path) {
+  if (!path) return path;
+
+  return Object.values(filters).reduce(
+    (result, filter) => filter(result),
+    path,
+  );
+}

--- a/src/s3-logger.mjs
+++ b/src/s3-logger.mjs
@@ -44,7 +44,7 @@ export class S3Logger {
     const data = {
       time: now,
       host: this.subsystemName,
-      url: referer || (this.req.headers.has('referer') ? this.req.headers.get('referer') : this.req.url),
+      url: cleanurl(referer || (this.req.headers.has('referer') ? this.req.headers.get('referer') : this.req.url)),
       user_agent: getMaskedUserAgent(this.req.headers),
       referer: cleanurl(this.req.headers.get('referer')),
       weight,

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -12,6 +12,7 @@
 // Pass the current time to facilitate unit testing
 import { isSpider } from './spiders.mjs';
 import { bots } from './bots.mjs';
+import { cleanPath } from './privacy.js';
 
 export function isReasonableWeight(weight) {
   return [1, // debug
@@ -252,25 +253,6 @@ export function getMaskedUserAgent(headers) {
   return 'undefined';
 }
 
-function cleanJWT(str) {
-  // sometimes we see JWTs in URLs or source or target values. These
-  // are always two segments of base64-encoded JSON and a signature,
-  // separated by three dots. When we find this, we replace the string
-  // with a generic placeholder.
-  if (str && typeof str.replace === 'function') {
-    return str.replace(/eyJ[a-zA-Z0-9]+\.eyJ[a-zA-Z0-9]+\.[a-zA-Z0-9]+/g, '<jwt>');
-  }
-  return str;
-}
-
-function cleanCode(str) {
-  // Use a regex to replace everything after 'trip/' with an empty string
-  if (str && typeof str.replace === 'function') {
-    return str.replace(/(trip\/)[A-Z0-9]{5,7}\/[A-Z]+/, '$1');
-  }
-  return str;
-}
-
 export function cleanurl(url) {
   // if URL does not parse, return it as is
   try {
@@ -280,11 +262,10 @@ export function cleanurl(url) {
     u.username = '';
     u.password = '';
     u.hash = '';
-    u.pathname = cleanJWT(u.pathname);
-    u.pathname = cleanCode(u.pathname);
+    u.pathname = cleanPath(u.pathname);
     return u.toString().replace(/@/g, '');
   } catch (e) {
-    return cleanCode(cleanJWT(url));
+    return cleanPath(url);
   }
 }
 

--- a/test/google-logger.test.mjs
+++ b/test/google-logger.test.mjs
@@ -168,4 +168,30 @@ describe('Test Google Logger', () => {
     const logged = JSON.parse(lastLogMessage);
     assert.equal('q1339', logged.id);
   });
+
+  it('Strips query parameters from all URL properties', () => {
+    const headers = new Map();
+    headers.set('x-forwarded-host', 'www.foo.com');
+    headers.set('referer', 'https://www.foo.com/referer?ref=123&tracking=456');
+    const url = new URL('https://www.foo.com/page?utm_source=test&utm_campaign=test');
+
+    const req = { headers, url };
+    const gl = new GoogleLogger(req);
+    gl.logRUM(
+      {},
+      'test123',
+      1,
+      'https://www.foo.com/referer?ref=123&tracking=456',
+      42,
+      'error',
+      'https://www.foo.com/target?dest=789&id=abc',
+      'https://www.foo.com/source?src=xyz&from=home',
+    );
+
+    const logged = JSON.parse(lastLogMessage);
+    assert.equal(logged.url, 'https://www.foo.com/referer');
+    assert.equal(logged.referer, 'https://www.foo.com/referer');
+    assert.equal(logged.target, 'https://www.foo.com/target');
+    assert.equal(logged.source, 'https://www.foo.com/source');
+  });
 });

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -46,12 +46,12 @@ describe('Test index', () => {
     assert.equal('text/plain; charset=utf-8', resp.headers.get('Content-Type'));
 
     const logged = JSON.parse(lastLogMessage);
-    assert.equal('error', logged.checkpoint);
-    assert.equal('http://blahblah/', logged.url);
-    assert.equal('desktop:chromeos:blink', logged.user_agent);
-    assert.equal(1, logged.weight);
-    assert.equal('somehost', logged.host);
-    assert.equal('blahblah', logged.hostname);
+    assert.equal(logged.checkpoint, 'error');
+    assert.equal(logged.url, 'http://blahblah/');
+    assert.equal(logged.user_agent, 'desktop:chromeos:blink');
+    assert.equal(logged.weight, 1);
+    assert.equal(logged.host, 'somehost');
+    assert.equal(logged.hostname, 'blahblah');
   });
 
   it('main GET generates ID', async () => {
@@ -116,15 +116,15 @@ describe('Test index', () => {
     const logged = JSON.parse(lastLogMessage);
     assert.equal('foobar', logged.id);
     assert(logged.time.toString().endsWith('.003'));
-    assert.equal('http://a.b.c/', logged.url);
+    assert.equal(logged.url, 'http://a.b.c/');
     assert.equal(10, logged.weight);
     assert.equal(42, logged.generation);
-    assert.equal('https://t/', logged.target);
-    assert.equal('1.2.3.4', logged.source);
+    assert.equal(logged.target, 'https://t/');
+    assert.equal(logged.source, '1.2.3.4');
     assert.equal(undefined, logged.a);
     assert.equal(123, logged.INP);
-    assert.equal('www.foobar.com', logged.host);
-    assert.equal('mobile', logged.user_agent);
+    assert.equal(logged.host, 'www.foobar.com');
+    assert.equal(logged.user_agent, 'mobile:opera:mini');
   });
 
   it('error handling', async () => {

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -124,7 +124,7 @@ describe('Test index', () => {
     assert.equal(undefined, logged.a);
     assert.equal(123, logged.INP);
     assert.equal(logged.host, 'www.foobar.com');
-    assert.equal(logged.user_agent, 'mobile:opera:mini');
+    assert.equal(logged.user_agent, 'mobile');
   });
 
   it('error handling', async () => {
@@ -469,7 +469,7 @@ describe('Test index', () => {
     assert.equal(logged.length, 1);
 
     const ld = JSON.parse(logged[0]);
-    assert.equal(ld.url, 'http://www.acme.org');
+    assert.equal(ld.url, 'http://www.acme.org/');
     assert.equal(ld.weight, 1);
     assert.equal(ld.id, 'xyz123');
     assert.equal(ld.checkpoint, 'top');

--- a/test/s3-logger.test.mjs
+++ b/test/s3-logger.test.mjs
@@ -106,4 +106,30 @@ describe('Test S3 Logger', () => {
     const logged = JSON.parse(lastLogMessage);
     assert.equal('q1339', logged.id);
   });
+
+  it('Strips query parameters from all URL properties', () => {
+    const headers = new Map();
+    headers.set('x-forwarded-host', 'www.foo.com');
+    headers.set('referer', 'https://www.foo.com/referer?ref=123&tracking=456');
+    const url = new URL('https://www.foo.com/page?utm_source=test&utm_campaign=test');
+
+    const req = { headers, url };
+    const gl = new S3Logger(req);
+    gl.logRUM(
+      {},
+      'test123',
+      1,
+      'https://www.foo.com/referer?ref=123&tracking=456',
+      42,
+      'error',
+      'https://www.foo.com/target?dest=789&id=abc',
+      'https://www.foo.com/source?src=xyz&from=home',
+    );
+
+    const logged = JSON.parse(lastLogMessage);
+    assert.equal(logged.url, 'https://www.foo.com/referer');
+    assert.equal(logged.referer, 'https://www.foo.com/referer');
+    assert.equal(logged.target, 'https://www.foo.com/target');
+    assert.equal(logged.source, 'https://www.foo.com/source');
+  });
 });

--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -138,6 +138,27 @@ Pellentesque viverra id magna vel varius. Lorem ipsum dolor sit amet, consectetu
     assert.equal(cleanurl(123), 123);
     assert.equal(cleanurl(''), '');
     assert.equal(cleanurl(null), null);
+
+    // PNR cleaning tests
+    // Positive cases - should be replaced
+    assert.equal(cleanurl('https://airline.com/manage/K26JNFQ/seat-map'), 'https://airline.com/manage/%3Cpnr%3E/seat-map');
+    assert.equal(cleanurl('https://airline.com/booking/LVQHQC/details'), 'https://airline.com/booking/%3Cpnr%3E/details');
+    assert.equal(cleanurl('https://airline.com/check-in/OV7GCC/status'), 'https://airline.com/check-in/%3Cpnr%3E/status');
+    // Multiple PNRs in same URL
+    assert.equal(cleanurl('https://airline.com/compare/SW7O2L/XYZ987'), 'https://airline.com/compare/%3Cpnr%3E/%3Cpnr%3E');
+
+    // Negative cases - should not be replaced
+    // Too short (4 chars)
+    assert.equal(cleanurl('https://example.com/path/ABC1/seat-map'), 'https://example.com/path/ABC1/seat-map');
+    // Too long (8 chars)
+    assert.equal(cleanurl('https://test.com/path/ABC12345/seat-map'), 'https://test.com/path/ABC12345/seat-map');
+    // Contains lowercase
+    assert.equal(cleanurl('https://demo.com/path/abc123/seat-map'), 'https://demo.com/path/abc123/seat-map');
+    // Contains special characters
+    assert.equal(cleanurl('https://site.com/path/ABC-123/seat-map'), 'https://site.com/path/ABC-123/seat-map');
+    // Common words that might look like PNRs but have low entropy
+    assert.equal(cleanurl('https://game.com/path/GAMERS/test'), 'https://game.com/path/GAMERS/test');
+    assert.equal(cleanurl('https://web.com/shape/CIRCLE/'), 'https://web.com/shape/CIRCLE/');
   });
 
   it('Get Forwarded Host', () => {


### PR DESCRIPTION
The current detection of PNRs is a bit overzealous. This PR adds checks for the telltale signs of machine-generated booking codes: high degree of randomness, hard to pronounce, letters mixed with numbers, all caps

It also fixes an issue with URL parameters being improperly stripped

- **fix: update URL handling in loggers to use cleanurl and add privacy.js for path sanitization**
- **feat: enhance privacy.js with PNR cleaning functionality and Shannon entropy calculation**
