### PR TITLE
fix(hlx): add CORS headers to helix-rum-enhancer responses and update tests

### DIFF
--- a/src/hlxpkgreg.mjs
+++ b/src/hlxpkgreg.mjs
@@ -75,6 +75,10 @@ export async function respondHelixPkgReg(req) {
 
   const ccMap = new Map();
   ccMap.set('cache-control', relver.cc);
+  ccMap.set('access-control-allow-origin', '*');
+  ccMap.set('access-control-allow-methods', 'GET, HEAD, OPTIONS');
+  ccMap.set('access-control-allow-headers', '*');
+  ccMap.set('access-control-expose-headers', '*');
   ccMap.set('x-rum-trace', 'hlx'); // Trace the backend used
   return cleanupResponse(beresp, req, ccMap);
 }

--- a/test/post-deploy.test.mjs
+++ b/test/post-deploy.test.mjs
@@ -414,5 +414,35 @@ import assert from 'assert';
       assert.strictEqual(resp.status, 404, `Expected 404 but got ${resp.status}. Response body: ${respTxt}`);
       assert.strictEqual(resp.headers.get('x-frame-options'), 'DENY');
     });
+
+    it('CORS headers are set for helix-rum-enhancer cwv plugin', async function test() {
+      if (!process.env.TEST_INTEGRATION) {
+        this.skip();
+      }
+      const response = await fetch(`https://${domain}/.rum/@adobe/helix-rum-enhancer@%5E2/src/plugins/cwv.js`, {
+        method: 'GET',
+      });
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(response.headers.get('access-control-allow-origin'), '*');
+      assert.strictEqual(response.headers.get('access-control-allow-methods'), 'GET, HEAD, OPTIONS');
+      assert.strictEqual(response.headers.get('access-control-allow-headers'), '*');
+      assert.strictEqual(response.headers.get('access-control-expose-headers'), '*');
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
+    });
+
+    it('CORS headers are set for helix-rum-enhancer webcomponent plugin', async function test() {
+      if (!process.env.TEST_INTEGRATION) {
+        this.skip();
+      }
+      const response = await fetch(`https://${domain}/.rum/@adobe/helix-rum-enhancer@%5E2/src/plugins/webcomponent.js`, {
+        method: 'GET',
+      });
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(response.headers.get('access-control-allow-origin'), '*');
+      assert.strictEqual(response.headers.get('access-control-allow-methods'), 'GET, HEAD, OPTIONS');
+      assert.strictEqual(response.headers.get('access-control-allow-headers'), '*');
+      assert.strictEqual(response.headers.get('access-control-expose-headers'), '*');
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
+    });
   });
 });


### PR DESCRIPTION
- Implemented CORS headers: `access-control-allow-origin`, `access-control-allow-methods`, `access-control-allow-headers`, and `access-control-expose-headers` in the `respondHelixPkgReg` function.
- Added integration tests to verify the presence of CORS headers for both the CWV and webcomponent plugins of the helix-rum-enhancer.
