### PR TITLE
feat(a11y): add support for a new accessibility checkpoint

### DIFF
--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -41,6 +41,7 @@ export function isValidCheckpoint(checkpoint) {
     // 'lcp', // not needed anymore, helix-specific
     'missingresource',
     'audience',
+    'a11y',
     'experiment',
     'formsubmit',
     '404',
@@ -78,6 +79,7 @@ export function isValidCheckpoint(checkpoint) {
 }
 
 export const sourceTargetValidator = {
+  a11y: (source = '') => source === 'on' || source === 'off',
   audience: (source = '', target = '') => source.match(/^[\w-]+$/)
     && target.match(/^[\w-:]+$/)
     && ['default', ...target.split(':')].includes(source),

--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -18,6 +18,7 @@ import {
   getForwardedHost,
   getMaskedUserAgent,
   getSubsystem,
+  isValidCheckpoint,
   isValidId,
   maskTime,
   sourceTargetValidator,

--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -228,6 +228,27 @@ Pellentesque viverra id magna vel varius. Lorem ipsum dolor sit amet, consectetu
         assert.ok(!sourceTargetValidator.experiment('foo!', 'bar?'));
       });
     });
+
+    describe('a11y', () => {
+      it('validates the checkpoint', () => {
+        assert.ok(isValidCheckpoint('a11y'));
+      });
+
+      it('has a validator for the "a11y" checkpoint', () => {
+        assert.ok(sourceTargetValidator.a11y);
+      });
+
+      it('validates that source is on or off', () => {
+        assert.ok(sourceTargetValidator.a11y('on'));
+        assert.ok(sourceTargetValidator.a11y('off'));
+        assert.ok(sourceTargetValidator.a11y('on', 'ignored'));
+        assert.ok(sourceTargetValidator.a11y('off', 'ignored'));
+
+        assert.ok(!sourceTargetValidator.a11y('true'));
+        assert.ok(!sourceTargetValidator.a11y(''));
+        assert.ok(!sourceTargetValidator.a11y());
+      });
+    });
   });
 
   it('id validation', () => {


### PR DESCRIPTION
Introduces a new accessibility checkpoint.
The current expectation is that it will have:
- checkpoint: `a11y`
- source: `on` or `off`
- target: `undefined`

We can later potentially add granularity to the `target` to report accessibility levels.

Will be used by https://github.com/adobe/helix-rum-enhancer/pull/445