### PR TITLE
feat: allow the new a11y sources

### DIFF
--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -79,7 +79,7 @@ export function isValidCheckpoint(checkpoint) {
 }
 
 export const sourceTargetValidator = {
-  a11y: (source = '') => source === 'on' || source === 'off',
+  a11y: (source = '') => ['off', 'on', 'low', 'medium', 'high'].includes(source),
   audience: (source = '', target = '') => source.match(/^[\w-]+$/)
     && target.match(/^[\w-:]+$/)
     && ['default', ...target.split(':')].includes(source),

--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -239,13 +239,19 @@ Pellentesque viverra id magna vel varius. Lorem ipsum dolor sit amet, consectetu
         assert.ok(sourceTargetValidator.a11y);
       });
 
-      it('validates that source is on or off', () => {
-        assert.ok(sourceTargetValidator.a11y('on'));
+      it('validates that source is off, on, low, medium, or high', () => {
         assert.ok(sourceTargetValidator.a11y('off'));
+        assert.ok(sourceTargetValidator.a11y('on'));
+        assert.ok(sourceTargetValidator.a11y('low'));
+        assert.ok(sourceTargetValidator.a11y('medium'));
+        assert.ok(sourceTargetValidator.a11y('high'));
         assert.ok(sourceTargetValidator.a11y('on', 'ignored'));
         assert.ok(sourceTargetValidator.a11y('off', 'ignored'));
 
         assert.ok(!sourceTargetValidator.a11y('true'));
+        assert.ok(!sourceTargetValidator.a11y('false'));
+        assert.ok(!sourceTargetValidator.a11y('enabled'));
+        assert.ok(!sourceTargetValidator.a11y('disabled'));
         assert.ok(!sourceTargetValidator.a11y(''));
         assert.ok(!sourceTargetValidator.a11y());
       });


### PR DESCRIPTION
Just adds support for `low`/`medium`/`high` sources as per https://github.com/adobe/helix-rum-enhancer/pull/456