### PR TITLE
Remove deprecated checkpoints from valid checkpoints list

### DIFF
--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -25,7 +25,6 @@ export function isValidCheckpoint(checkpoint) {
   const knowncheckpoints = [
     'loadresource',
     'cwv',
-    'cwv2', // ekrem
     'click',
     'top',
     // 'lazy', // killed, not used in minirum anymore
@@ -48,7 +47,6 @@ export function isValidCheckpoint(checkpoint) {
     // 'convert', // not valuable
     'search',
     'unsupported',
-    'genai:prompt:generate',
     'fill', // when a form field is filled
     // 'formviews', // no data in last 30 days
     // 'formready', // no data in last 30 days


### PR DESCRIPTION
## Summary
- Cleans up the `isValidCheckpoint` function by removing obsolete checkpoints: `cwv2` and `genai:prompt:generate`
- Helps maintain accurate and up-to-date checkpoint validation within the collector utility

## Changes

### Code Cleanup
- **src/utils.mjs**: Removed `cwv2` and `genai:prompt:generate` from the `knowncheckpoints` and related arrays used by `isValidCheckpoint`

## Test plan
- [x] Confirmed build passes without errors
- [x] Verified that removed checkpoints are no longer recognized by `isValidCheckpoint`
- [x] Checked for no regressions in existing valid checkpoint handling

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/429f4754-dc84-4754-8ecf-4e147704489f