### PR TITLE
feat(utils): remove deprecated checkpoints from isValidCheckpoint list

### DIFF
--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -25,7 +25,6 @@ export function isValidCheckpoint(checkpoint) {
   const knowncheckpoints = [
     'loadresource',
     'cwv',
-    'cwv2', // ekrem
     'click',
     'top',
     // 'lazy', // killed, not used in minirum anymore
@@ -48,7 +47,6 @@ export function isValidCheckpoint(checkpoint) {
     // 'convert', // not valuable
     'search',
     'unsupported',
-    'genai:prompt:generate',
     'fill', // when a form field is filled
     // 'formviews', // no data in last 30 days
     // 'formready', // no data in last 30 days


### PR DESCRIPTION
## Summary
- Removed `cwv2` checkpoint from the allowlist (deprecated)
- Removed `genai:prompt:generate` checkpoint from the allowlist (no longer used)

This is a feature commit to trigger a new release with these checkpoint removals.

## Test plan
- [x] Tests pass (pre-existing test failure in test/index.test.mjs is unrelated)
- [x] Changes reviewed and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)