### PR TITLE
fix: add more url constraints

### DIFF
--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -264,9 +264,9 @@ function cleanJWT(str) {
 }
 
 function cleanCode(str) {
-  // Use a regex to replace everything after and including the & char with an empty string
-  if (str && typeof str.replace === 'function' && str.includes('&')) {
-    return str.replace(/(&).+/, '');
+  // Use a regex to replace everything after and including the & and = chars with an empty string
+  if (str && typeof str.replace === 'function' && str.includes('&') && str.includes('=')) {
+    return str.replace(/(&.+=.+).+/, '');
   }
   // Use a regex to replace everything after 'trip/' with an empty string
   if (str && typeof str.replace === 'function') {

--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -135,6 +135,7 @@ Pellentesque viverra id magna vel varius. Lorem ipsum dolor sit amet, consectetu
     assert.equal('http://foo.bar.com/test', cleanurl('http://foo.bar.com/test?foo=bar#with-fragment'));
     assert.equal('http://foo.bar.com:9091/test', cleanurl('http://someone:something@foo.bar.com:9091/test'));
     assert.equal('http://foo.bar.com/test/loc=en_us', cleanurl('http://foo.bar.com/test/loc=en_us&tracknum=12345'));
+    assert.equal('http://foo.bar.com/test/loc=en_us&tracknum', cleanurl('http://foo.bar.com/test/loc=en_us&tracknum'));
     // jwt tokens in URLs are discarded
     assert.equal(cleanurl('https://www.example.com/eyJmYWtlIjogdHJ1ZX0.eyJmYWtlIjogdHJ1ZX0.c3VwZXJmYWtl/auth'), 'https://www.example.com/%3Cjwt%3E/auth');
     assert.equal(cleanurl(123), 123);


### PR DESCRIPTION
URLs which include segments resembling querystring parameters but without the `?` char were not previously being filtered out.  This PR excludes anything after (and including) the `&` char which is not typically found in URLs.

Unit test included.
