### PR TITLE
feat: use client-supplied ua field for webdriver bot classification

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -261,7 +261,10 @@ export async function main(req, ctx) {
       ? {
         url: req.url,
         method: req.method,
-        headers: { get: (k) => (k === 'user-agent' ? ua : req.headers.get(k)) },
+        headers: {
+          get: (k) => (k === 'user-agent' ? ua : req.headers.get(k)),
+          has: (k) => req.headers.has(k),
+        },
       }
       : req;
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -237,6 +237,7 @@ export async function main(req, ctx) {
       target,
       source,
       t,
+      ua,
     } = body;
 
     if (!id && id !== '') {
@@ -256,18 +257,26 @@ export async function main(req, ctx) {
       }
     });
 
+    const effectiveReq = ua
+      ? {
+          url: req.url,
+          method: req.method,
+          headers: { get: (k) => (k === 'user-agent' ? ua : req.headers.get(k)) },
+        }
+      : req;
+
     try {
       if (ctx?.runtime?.name === 'compute-at-edge') {
-        const c = new CoralogixLogger(req);
+        const c = new CoralogixLogger(effectiveReq);
         c.logRUM(cwv, id, weight, referer || referrer, generation, checkpoint, target, source, t);
 
-        const s = new S3Logger(req);
+        const s = new S3Logger(effectiveReq);
         s.logRUM(cwv, id, weight, referer || referrer, generation, checkpoint, target, source, t);
 
-        const g = new GoogleLogger(req);
+        const g = new GoogleLogger(effectiveReq);
         g.logRUM(cwv, id, weight, referer || referrer, generation, checkpoint, target, source, t);
       } else {
-        const l = new ConsoleLogger(req, ctx?.altConsole);
+        const l = new ConsoleLogger(effectiveReq, ctx?.altConsole);
         l.logRUM(cwv, id, weight, referer || referrer, generation, checkpoint, target, source, t);
       }
     } catch (err) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -259,10 +259,10 @@ export async function main(req, ctx) {
 
     const effectiveReq = ua
       ? {
-          url: req.url,
-          method: req.method,
-          headers: { get: (k) => (k === 'user-agent' ? ua : req.headers.get(k)) },
-        }
+        url: req.url,
+        method: req.method,
+        headers: { get: (k) => (k === 'user-agent' ? ua : req.headers.get(k)) },
+      }
       : req;
 
     try {

--- a/test/index-ua.test.mjs
+++ b/test/index-ua.test.mjs
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+import assert from 'assert';
+import { before, describe, it } from 'node:test';
+import { lastLogMessage } from '../src/logger.mjs';
+
+const methods = {};
+
+global.addEventListener = function addEventListener() {};
+
+describe('Test index - ua body field', () => {
+  before(async () => {
+    const mod = await import('../src/index.mjs');
+    Object.keys(mod).forEach((f) => {
+      methods[f] = mod[f];
+    });
+  });
+
+  it('beacon with ua field uses overridden user agent for bot classification', async () => {
+    const headers = new Map();
+    headers.set('host', 'www.example.com');
+    headers.set('user-agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36');
+
+    const json = () => ({
+      weight: 1,
+      id: 'webdriver-test',
+      checkpoint: 'top',
+      ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 +http://navigator.webdriver',
+    });
+
+    const req = { headers, json };
+    req.method = 'POST';
+    req.url = 'http://www.example.com/.rum/1';
+
+    const ctx = { runtime: { name: 'compute-at-edge' } };
+    const resp = await methods.main(req, ctx);
+
+    assert.equal(201, resp.status);
+    const logged = JSON.parse(lastLogMessage);
+    assert.equal('bot', logged.user_agent);
+  });
+
+  it('beacon without ua field uses real user-agent header', async () => {
+    const headers = new Map();
+    headers.set('host', 'www.example.com');
+    headers.set('user-agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36');
+
+    const json = () => ({
+      weight: 1,
+      id: 'normal-browser-test',
+      checkpoint: 'top',
+    });
+
+    const req = { headers, json };
+    req.method = 'POST';
+    req.url = 'http://www.example.com/.rum/1';
+
+    const ctx = { runtime: { name: 'compute-at-edge' } };
+    const resp = await methods.main(req, ctx);
+
+    assert.equal(201, resp.status);
+    const logged = JSON.parse(lastLogMessage);
+    assert.equal('desktop:windows:blink', logged.user_agent);
+  });
+});

--- a/test/post-deploy.test.mjs
+++ b/test/post-deploy.test.mjs
@@ -272,6 +272,25 @@ BACKENDS.forEach((env) => {
       assert.strictEqual(response.headers.get('x-rum-trace'), 'hlx');
     });
 
+    it('RUM collection with webdriver ua field returns 201', async function test() {
+      if (!process.env.TEST_INTEGRATION) {
+        this.skip();
+      }
+      const response = await fetch(`https://${domain}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          id: 'webdriver-bot-test',
+          weight: 1,
+          ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 +http://navigator.webdriver',
+        }),
+      });
+      assert.strictEqual(response.status, 201);
+      assert.strictEqual(response.headers.get('x-frame-options'), 'DENY');
+    });
+
     it('Missing id returns 400', async function test() {
       if (!process.env.TEST_INTEGRATION) {
         this.skip();

--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -111,6 +111,12 @@ Pellentesque viverra id magna vel varius. Lorem ipsum dolor sit amet, consectetu
     });
   });
 
+  it('Classifies webdriver-annotated UA as bot', () => {
+    const realUA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+    const webdriverUA = `${realUA} +http://navigator.webdriver`;
+    assert.equal('bot', getMaskedUserAgent(getUserAgentHeaders(webdriverUA)));
+  });
+
   it('Mask user agent CloudFront', () => {
     const hm1 = new Map();
     hm1.set('CloudFront-Is-Desktop-Viewer', 'true');


### PR DESCRIPTION
## Summary

- `helix-rum-js` now sends a `ua` body field when `navigator.webdriver` is `true`, containing the real UA with `+http://navigator.webdriver` appended
- Extracts `ua` from the beacon body and wraps the request in a lightweight `effectiveReq` object that shadows `user-agent` for all loggers
- All four loggers (`CoralogixLogger`, `S3Logger`, `GoogleLogger`, `ConsoleLogger`) pick up the overridden UA transparently — **no logger files were changed**
- `getMaskedUserAgent` is unchanged; the existing `+http://` branch handles classification, returning `bot`
- Traffic is **collected, not dropped**, so webdriver bot volume can be estimated and excluded in reporting as needed

## Test plan

- [ ] `test/utils.test.mjs`: UA string containing `+http://navigator.webdriver` → `getMaskedUserAgent` returns `bot`
- [ ] No `ua` body field → behaviour unchanged, real `user-agent` header used as before
- [ ] 91/91 utils tests pass; pre-existing `esmock` missing-package failure in `index.test.mjs` is unrelated to this change

Companion PR in helix-rum-js: https://github.com/adobe/helix-rum-js/pull/339

🤖 Generated with [Claude Code](https://claude.com/claude-code)