### PR TITLE
feat: preserve port for loopback hosts in cluster hostname

### DIFF
--- a/src/google-logger.mjs
+++ b/src/google-logger.mjs
@@ -13,6 +13,7 @@ import { Logger } from './logger.mjs';
 import {
   bloatControl,
   cleanurl,
+  getHostname,
   getMaskedTime,
   getMaskedUserAgent,
   getSubsystem,
@@ -58,12 +59,12 @@ export class GoogleLogger {
 
     const hn = (url) => {
       try {
-        return (new URL(url)).hostname;
+        return getHostname(url);
       } catch (e) {
         if (this.req.headers.has('referer')) {
-          return new URL(this.req.headers.get('referer')).hostname;
+          return getHostname(this.req.headers.get('referer'));
         }
-        return new URL(this.req.url).hostname;
+        return getHostname(this.req.url);
       }
     };
 

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -295,6 +295,26 @@ export function cleanurl(url) {
   }
 }
 
+/**
+ * Determine the hostname to record for a measured page. Normally this is the
+ * URL's hostname without the port, which keeps clustering cardinality low for
+ * production traffic. For loopback / local development hosts the port is the
+ * only thing that distinguishes one local app from another (e.g. a SLICC dev
+ * server on localhost:5710 vs another tool on localhost:3000), so for those we
+ * preserve it by returning the host (hostname:port). IPv6 loopback and
+ * `*.localhost` names are treated the same way.
+ * @param {string} url the URL to extract the hostname from
+ * @returns {string} the hostname, including the port for loopback hosts
+ */
+export function getHostname(url) {
+  const { hostname, host } = new URL(url);
+  const isLoopback = hostname === 'localhost'
+    || hostname === '127.0.0.1'
+    || hostname === '[::1]'
+    || hostname.endsWith('.localhost');
+  return isLoopback ? host : hostname;
+}
+
 export function getForwardedHost(fhh) {
   const hosts = fhh.split(',');
 

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -54,6 +54,27 @@ describe('Test index', () => {
     assert.equal('blahblah', logged.hostname);
   });
 
+  it('main GET preserves port for localhost in cluster hostname', async () => {
+    const headers = new Map();
+    headers.set('host', 'somehost');
+    headers.set('user-agent', 'Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36');
+
+    const req = { headers };
+    req.method = 'GET';
+    req.url = 'http://foo.bar.org?data={"referer":"http://localhost:5710/index.html", "checkpoint": "error"}';
+
+    const ctx = { runtime: { name: 'compute-at-edge' } };
+
+    const resp = await methods.main(req, ctx);
+    assert.equal(201, resp.status);
+
+    const logged = JSON.parse(lastLogMessage);
+    assert.equal('http://localhost:5710/index.html', logged.url);
+    // a bare hostname would lose the port, collapsing every local dev app into
+    // a single `localhost` bucket — the port is what keeps them distinguishable
+    assert.equal('localhost:5710', logged.hostname);
+  });
+
   it('main GET generates ID', async () => {
     const headers = new Map();
     const req = { headers };

--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -16,6 +16,7 @@ import {
   cleanurl,
   extractAdobeRoutingInfo,
   getForwardedHost,
+  getHostname,
   getMaskedUserAgent,
   getSubsystem,
   isValidCheckpoint,
@@ -193,6 +194,27 @@ Pellentesque viverra id magna vel varius. Lorem ipsum dolor sit amet, consectetu
 
     // Trip codes are cleaned
     assert.equal(cleanurl('https://booking.com/trip/AB123C/DETAILS'), 'https://booking.com/trip/');
+  });
+
+  it('Get Hostname (port preserved for loopback hosts)', () => {
+    // production hosts: port is stripped to keep clustering cardinality low
+    assert.equal('www.example.com', getHostname('https://www.example.com/some/path'));
+    assert.equal('www.example.com', getHostname('https://www.example.com:8443/some/path'));
+    assert.equal('main--site--owner.aem.live', getHostname('https://main--site--owner.aem.live/'));
+
+    // loopback hosts: port preserved so local dev apps stay distinguishable
+    assert.equal('localhost:5710', getHostname('http://localhost:5710/index.html'));
+    assert.equal('localhost:3000', getHostname('http://localhost:3000/'));
+    assert.equal('127.0.0.1:5710', getHostname('http://127.0.0.1:5710/'));
+    assert.equal('[::1]:5710', getHostname('http://[::1]:5710/'));
+    assert.equal('tefal.localhost:8080', getHostname('http://tefal.localhost:8080/'));
+
+    // loopback host without an explicit (or with a default) port: nothing to add
+    assert.equal('localhost', getHostname('http://localhost/'));
+    assert.equal('localhost', getHostname('http://localhost:80/'));
+
+    // invalid URLs throw, exactly as the previous `new URL(...).hostname` did
+    assert.throws(() => getHostname('not a url'));
   });
 
   it('Get Forwarded Host', () => {


### PR DESCRIPTION
## Problem

The BigQuery `cluster` table derives its `hostname` field in `google-logger.mjs` via `new URL(url).hostname`, which **strips the port**. For production hosts that's the right call — it keeps clustering cardinality low. But for loopback / local development hosts the port is the *only* discriminator: `localhost:5710`, `localhost:3000`, etc. all collapse into a single shared `localhost` bucket (millions of rows from every developer), so a given local app's RUM can't be isolated by hostname at all.

## Change

- Add `getHostname(url)` to `utils.mjs`: returns the host **with** its port for loopback hosts (`localhost`, `*.localhost`, `127.0.0.1`, `[::1]`) and the bare hostname for everything else.
- Use it in the Google (BigQuery) logger's hostname derivation, preserving the existing referer/req-url fallback chain.

Production hostnames are unchanged, so there's no cardinality or PII impact on existing traffic.

## S3 logger

Left as-is on purpose: the S3 record has no derived `hostname` field, and its `url` field already preserves the port via `cleanurl()` (which only strips query/credentials/hash). So the port is already tracked in S3.

## Tests

- `getHostname` unit tests in `test/utils.test.mjs` (production stripped, loopback variants preserved, default/absent ports, invalid-URL throws).
- Integration test in `test/index.test.mjs` asserting a `http://localhost:5710/...` beacon logs `hostname: "localhost:5710"`.
- Full suite: 194 passing, 0 failing; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)