### PR TITLE
feat: add bot subtype classification for AI and search agents

### DIFF
--- a/src/bots.mjs
+++ b/src/bots.mjs
@@ -202,18 +202,52 @@ export const bots = {
     {
       user_agent: 'Ai2Bot-Dolma',
       regex: 'Ai2Bot-Dolma',
+      subtype: 'ai2bot-dolma',
     },
     {
       user_agent: 'GPTBot',
       regex: 'GPTBot',
+      subtype: 'gptbot',
+    },
+    {
+      user_agent: 'ChatGPT-User',
+      regex: 'ChatGPT-User',
+      subtype: 'chatgpt-user',
+    },
+    {
+      user_agent: 'OAI-SearchBot',
+      regex: 'OAI-SearchBot',
+      subtype: 'oai-searchbot',
+    },
+    {
+      user_agent: 'OAI-AdsBot',
+      regex: 'OAI-AdsBot',
+      subtype: 'oai-adsbot',
     },
     {
       user_agent: 'Claude-Web',
       regex: 'Claude-Web',
+      subtype: 'claude-web',
+    },
+    {
+      user_agent: 'Claude-User',
+      regex: 'Claude-User',
+      subtype: 'claude-user',
+    },
+    {
+      user_agent: 'ClaudeBot',
+      regex: 'ClaudeBot',
+      subtype: 'claudebot',
+    },
+    {
+      user_agent: 'Claude-SearchBot',
+      regex: 'Claude-SearchBot',
+      subtype: 'claude-searchbot',
     },
     {
       user_agent: 'anthropic-ai',
       regex: 'anthropic-ai',
+      subtype: 'anthropic-ai',
     },
     {
       user_agent: 'Google-Extended',
@@ -222,22 +256,87 @@ export const bots = {
     {
       user_agent: 'FacebookBot',
       regex: 'FacebookBot',
+      subtype: 'facebookbot',
     },
     {
       user_agent: 'Applebot-Extended',
       regex: 'Applebot.*Extended',
+      subtype: 'applebot-extended',
     },
     {
       user_agent: 'Meta-ExternalAgent',
       regex: 'Meta-ExternalAgent',
+      subtype: 'meta-externalagent',
     },
     {
       user_agent: 'PerplexityBot',
       regex: 'PerplexityBot',
+      subtype: 'perplexitybot',
+    },
+    {
+      user_agent: 'Perplexity-User',
+      regex: 'Perplexity-User',
+      subtype: 'perplexity-user',
     },
     {
       user_agent: 'YouBot',
       regex: 'YouBot',
+      subtype: 'youbot',
+    },
+    {
+      user_agent: 'cohere-ai',
+      regex: 'cohere-ai',
+      subtype: 'cohere-ai',
+    },
+    {
+      user_agent: 'Bytespider',
+      regex: 'Bytespider',
+      subtype: 'bytespider',
+    },
+    {
+      user_agent: 'DuckAssistBot',
+      regex: 'DuckAssistBot',
+      subtype: 'duckassistbot',
+    },
+    {
+      user_agent: 'Amazonbot',
+      regex: 'Amazonbot',
+      subtype: 'amazonbot',
+    },
+    {
+      user_agent: 'MistralAI-User',
+      regex: 'MistralAI-User',
+      subtype: 'mistralai-user',
+    },
+    {
+      user_agent: 'DeepSeekBot',
+      regex: 'DeepSeekBot',
+      subtype: 'deepseekbot',
+    },
+    {
+      user_agent: 'meta-externalfetcher',
+      regex: 'meta-externalfetcher',
+      subtype: 'meta-externalfetcher',
+    },
+    {
+      user_agent: 'meta-webindexer',
+      regex: 'meta-webindexer',
+      subtype: 'meta-webindexer',
+    },
+    {
+      user_agent: 'Bravebot',
+      regex: 'Bravebot',
+      subtype: 'bravebot',
+    },
+    {
+      user_agent: 'AI2Bot',
+      regex: 'AI2Bot',
+      subtype: 'ai2bot',
+    },
+    {
+      user_agent: 'Diffbot',
+      regex: 'Diffbot',
+      subtype: 'diffbot',
     },
   ],
   Search: [
@@ -252,6 +351,7 @@ export const bots = {
     {
       user_agent: 'YandexRenderResourcesBot/1.0',
       regex: 'Yandex',
+      subtype: 'yandexbot',
     },
     {
       user_agent: 'MS-Search Crawler',
@@ -260,6 +360,7 @@ export const bots = {
     {
       user_agent: 'Bingbot/2.0 various versions',
       regex: 'bingbot',
+      subtype: 'bingbot',
     },
     {
       user_agent: 'Googlebot/2.1',
@@ -268,6 +369,17 @@ export const bots = {
     {
       user_agent: 'Applebot/0.1',
       regex: 'Applebot',
+      subtype: 'applebot',
+    },
+    {
+      user_agent: 'DuckDuckBot',
+      regex: 'DuckDuckBot',
+      subtype: 'duckduckbot',
+    },
+    {
+      user_agent: 'Baiduspider',
+      regex: 'Baiduspider',
+      subtype: 'baiduspider',
     },
     {
       user_agent: 'AddSearchBot/1.0',
@@ -346,6 +458,7 @@ export const bots = {
       // per se, so it's not included in the AI category
       user_agent: 'CCBot',
       regex: 'CCBot',
+      subtype: 'ccbot',
     },
   ],
   Translation: [

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -180,12 +180,14 @@ function getDesktopOS(userAgent) {
  * @returns {Enumerator('', ':search', ':seo', ':social', ':ai', ':security')} the bot type
  */
 function getBotType(userAgent) {
-  const type = Object
-    .entries(bots)
-    .find(([, botList]) => (botList
-      .map(({ regex }) => new RegExp(regex, 'i'))
-      .find((re) => re.test(userAgent))));
-  return type ? `:${type[0].toLowerCase()}` : '';
+  for (const [category, botList] of Object.entries(bots)) {
+    const matched = botList.find(({ regex }) => new RegExp(regex, 'i').test(userAgent));
+    if (matched) {
+      const subtype = matched.subtype ? `:${matched.subtype}` : '';
+      return `:${category.toLowerCase()}${subtype}`;
+    }
+  }
+  return '';
 }
 
 function getBrowserEngine(userAgent) {

--- a/test/fixtures/user-agents.json
+++ b/test/fixtures/user-agents.json
@@ -2,7 +2,7 @@
   {
     "desc": "Baiduspider",
     "ua": "Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)",
-    "expected": "bot"
+    "expected": "bot:search:baiduspider"
   },
   {
     "desc": "HubSpot Crawler",
@@ -348,5 +348,135 @@
     "desc": "Windows desktop",
     "ua": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0",
     "expected": "desktop:windows:gecko"
+  },
+  {
+    "desc": "GPTBot",
+    "ua": "GPTBot",
+    "expected": "bot:ai:gptbot"
+  },
+  {
+    "desc": "ChatGPT-User",
+    "ua": "ChatGPT-User (+https://openai.com/bot)",
+    "expected": "bot:ai:chatgpt-user"
+  },
+  {
+    "desc": "OAI-SearchBot",
+    "ua": "OAI-SearchBot",
+    "expected": "bot:ai:oai-searchbot"
+  },
+  {
+    "desc": "OAI-AdsBot",
+    "ua": "OAI-AdsBot",
+    "expected": "bot:ai:oai-adsbot"
+  },
+  {
+    "desc": "ClaudeBot",
+    "ua": "ClaudeBot",
+    "expected": "bot:ai:claudebot"
+  },
+  {
+    "desc": "Claude-User",
+    "ua": "Claude-User (+https://www.anthropic.com)",
+    "expected": "bot:ai:claude-user"
+  },
+  {
+    "desc": "Claude-SearchBot",
+    "ua": "Claude-SearchBot",
+    "expected": "bot:ai:claude-searchbot"
+  },
+  {
+    "desc": "anthropic-ai",
+    "ua": "anthropic-ai (+https://www.anthropic.com/product)",
+    "expected": "bot:ai:anthropic-ai"
+  },
+  {
+    "desc": "PerplexityBot",
+    "ua": "PerplexityBot",
+    "expected": "bot:ai:perplexitybot"
+  },
+  {
+    "desc": "Perplexity-User",
+    "ua": "Perplexity-User (+https://www.perplexity.ai/bot)",
+    "expected": "bot:ai:perplexity-user"
+  },
+  {
+    "desc": "DuckAssistBot",
+    "ua": "DuckAssistBot",
+    "expected": "bot:ai:duckassistbot"
+  },
+  {
+    "desc": "Amazonbot",
+    "ua": "Amazonbot",
+    "expected": "bot:ai:amazonbot"
+  },
+  {
+    "desc": "MistralAI-User",
+    "ua": "MistralAI-User (+https://mistral.ai)",
+    "expected": "bot:ai:mistralai-user"
+  },
+  {
+    "desc": "DeepSeekBot",
+    "ua": "DeepSeekBot",
+    "expected": "bot:ai:deepseekbot"
+  },
+  {
+    "desc": "Bytespider",
+    "ua": "Bytespider",
+    "expected": "bot:ai:bytespider"
+  },
+  {
+    "desc": "cohere-ai",
+    "ua": "cohere-ai (+https://cohere.com)",
+    "expected": "bot:ai:cohere-ai"
+  },
+  {
+    "desc": "Google-Extended (no subtype)",
+    "ua": "Google-Extended (+http://www.google.com/bot.html)",
+    "expected": "bot:ai"
+  },
+  {
+    "desc": "meta-externalfetcher",
+    "ua": "meta-externalfetcher (+https://www.facebook.com/externalhit_uatext.php)",
+    "expected": "bot:ai:meta-externalfetcher"
+  },
+  {
+    "desc": "meta-webindexer",
+    "ua": "meta-webindexer (+https://www.facebook.com/externalhit_uatext.php)",
+    "expected": "bot:ai:meta-webindexer"
+  },
+  {
+    "desc": "Bravebot",
+    "ua": "Bravebot",
+    "expected": "bot:ai:bravebot"
+  },
+  {
+    "desc": "AI2Bot",
+    "ua": "AI2Bot",
+    "expected": "bot:ai:ai2bot"
+  },
+  {
+    "desc": "Diffbot",
+    "ua": "Diffbot",
+    "expected": "bot:ai:diffbot"
+  },
+  {
+    "desc": "bingbot (search subtype)",
+    "ua": "bingbot",
+    "expected": "bot:search:bingbot"
+  },
+  {
+    "desc": "YandexBot (search subtype)",
+    "ua": "YandexBot",
+    "expected": "bot:search:yandexbot"
+  },
+  {
+    "desc": "DuckDuckBot (search subtype)",
+    "ua": "DuckDuckBot",
+    "expected": "bot:search:duckduckbot"
+  },
+  {
+    "desc": "CCBot (archive subtype)",
+    "ua": "CCBot",
+    "expected": "bot:archive:ccbot"
   }
 ]

--- a/test/fixtures/user-agents.json
+++ b/test/fixtures/user-agents.json
@@ -460,6 +460,36 @@
     "expected": "bot:ai:diffbot"
   },
   {
+    "desc": "Ai2Bot-Dolma",
+    "ua": "Ai2Bot-Dolma",
+    "expected": "bot:ai:ai2bot-dolma"
+  },
+  {
+    "desc": "Claude-Web",
+    "ua": "Claude-Web (+https://www.anthropic.com/claude-web)",
+    "expected": "bot:ai:claude-web"
+  },
+  {
+    "desc": "FacebookBot",
+    "ua": "FacebookBot",
+    "expected": "bot:ai:facebookbot"
+  },
+  {
+    "desc": "Applebot-Extended (AI, not search)",
+    "ua": "Applebot-Extended/0.1",
+    "expected": "bot:ai:applebot-extended"
+  },
+  {
+    "desc": "Meta-ExternalAgent",
+    "ua": "Meta-ExternalAgent (+https://developers.facebook.com/docs/sharing/webmasters/)",
+    "expected": "bot:ai:meta-externalagent"
+  },
+  {
+    "desc": "YouBot",
+    "ua": "YouBot",
+    "expected": "bot:ai:youbot"
+  },
+  {
     "desc": "bingbot (search subtype)",
     "ua": "bingbot",
     "expected": "bot:search:bingbot"
@@ -473,6 +503,11 @@
     "desc": "DuckDuckBot (search subtype)",
     "ua": "DuckDuckBot",
     "expected": "bot:search:duckduckbot"
+  },
+  {
+    "desc": "Applebot (search subtype)",
+    "ua": "Applebot/0.1",
+    "expected": "bot:search:applebot"
   },
   {
     "desc": "CCBot (archive subtype)",


### PR DESCRIPTION
## Context

The Optimize at Edge team needs to continuously monitor how individual LLM/AI agents interact with Edge Delivery sites (whether they execute JS, interact with page content, etc.).

Today these agents collapse into a single `bot:ai` classification. This PR introduces a `subtype` so each agent is distinguishable, e.g. `bot:ai:claudebot`, `bot:ai:gptbot`, `bot:ai:perplexitybot`.

## Changes

- **`src/bots.mjs`**: added a `subtype` field to existing AI/Search/Archive bot definitions, and added new agents.
- **`src/utils.mjs`**: `getBotType()` now returns `bot:<category>:<subtype>` when a `subtype` is defined, falling back to `bot:<category>` otherwise. Behavior is unchanged for bots without a subtype.
- **`test/fixtures/user-agents.json`**: added test cases for every new subtype.

## Classification

New agents in **`AI`** → `bot:ai:<subtype>`:
`ChatGPT-User`, `OAI-SearchBot`, `OAI-AdsBot`, `Claude-User`, `ClaudeBot`, `Claude-SearchBot`, `Perplexity-User`, `cohere-ai`, `Bytespider`, `DuckAssistBot`, `Amazonbot`, `MistralAI-User`, `DeepSeekBot`, `meta-externalfetcher`, `meta-webindexer`, `Bravebot`, `AI2Bot`, `Diffbot`

New agents in **`Search`** → `bot:search:<subtype>`:
`DuckDuckBot`, `Baiduspider`

Existing bots that gained a `subtype` (category unchanged):
- AI: `GPTBot`, `Claude-Web`, `anthropic-ai`, `FacebookBot`, `Applebot-Extended`, `Meta-ExternalAgent`, `PerplexityBot`, `YouBot`, `Ai2Bot-Dolma`
- Search: `bingbot`, `Yandex`, `Applebot`
- Archive: `CCBot`

## Notes

- Categories were verified against [knownagents.com](https://knownagents.com/agents) (darkvisitors), the [`ai.robots.txt`](https://github.com/ai-robots-txt/ai.robots.txt) repo, and official vendor docs.
- **No existing bot categories were changed** — only `subtype` fields were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)